### PR TITLE
Implement OHLC validation and tests

### DIFF
--- a/mw/utils/ohlc_checks.py
+++ b/mw/utils/ohlc_checks.py
@@ -3,7 +3,27 @@ OHLC integrity checks (stub).
 """
 import pandas as pd
 
+
 def validate_ohlc(df: pd.DataFrame) -> pd.Series:
-    """Return boolean mask of rows passing L <= min(O,C) <= max(O,C) <= H."""
-    # TODO: implement
-    raise NotImplementedError
+    """Return boolean mask for ``low <= min(open, close) <= max(open, close) <= high``.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame containing at least ``open``, ``high``, ``low`` and ``close``
+        columns.
+
+    Returns
+    -------
+    pd.Series
+        Boolean Series indexed like ``df`` where ``True`` indicates the row
+        satisfies the OHLC relationship.
+    """
+
+    # Compute min/max between open and close for each row
+    oc = df[["open", "close"]]
+    min_val = oc.min(axis=1)
+    max_val = oc.max(axis=1)
+
+    # Validate the min/max values lie within the low/high bounds
+    return (df["low"] <= min_val) & (min_val <= max_val) & (max_val <= df["high"])

--- a/tests/test_ohlc_checks.py
+++ b/tests/test_ohlc_checks.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+import sys
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from mw.utils.ohlc_checks import validate_ohlc
+
+
+def test_validate_ohlc_various_rows():
+    df = pd.DataFrame(
+        {
+            "open": [1, 2, 1.5, 1, 1],
+            "high": [2.5, 2.5, 1.8, 1, 0.5],
+            "low": [0.5, 1.5, 1.0, 1, 0.5],
+            "close": [2, 1, 2, 1, 1],
+        }
+    )
+    # rows: valid, low>min, max>high, flat valid, flat invalid
+    expected = pd.Series([True, False, False, True, False], dtype=bool)
+    result = validate_ohlc(df)
+    pd.testing.assert_series_equal(result, expected, check_names=False)
+


### PR DESCRIPTION
## Summary
- add validate_ohlc to verify low/high bounds against open/close
- introduce tests for valid, invalid, and flat OHLC rows

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a90d496cdc83228920dc2cf9accc56