### PR TITLE
Implement atomic JSON writer and add round-trip test

### DIFF
--- a/mw/utils/persistence.py
+++ b/mw/utils/persistence.py
@@ -1,12 +1,43 @@
+"""Persistence helpers for common file formats.
+
+Currently only JSON writing is implemented. The helper ensures that data is
+written atomically so that partially written files are not left behind when a
+process is interrupted.
 """
-Persistence helpers (stub): parquet, json, safe append, hashing.
-"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Dict
+
 import pandas as pd
+
 
 def write_parquet(df: pd.DataFrame, path: str) -> None:
     # TODO: implement
     raise NotImplementedError
 
-def write_json(obj: dict, path: str) -> None:
-    # TODO: implement
-    raise NotImplementedError
+
+def write_json(obj: Dict[str, Any], path: str) -> None:
+    """Serialize ``obj`` as JSON and write it to ``path`` atomically.
+
+    The object is first written to a temporary file using UTF-8 encoding and is
+    then moved into place with :func:`os.replace`, providing atomic semantics on
+    both POSIX and Windows platforms.
+    """
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.NamedTemporaryFile(
+        "w", delete=False, dir=str(target.parent), encoding="utf-8"
+    ) as tmp:
+        json.dump(obj, tmp, ensure_ascii=False)
+        tmp.flush()
+        os.fsync(tmp.fileno())
+        temp_name = tmp.name
+
+    os.replace(temp_name, target)
+

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import sys
+import json
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from mw.utils.persistence import write_json
+
+
+def test_write_json_round_trip(tmp_path):
+    data = {"key": "value", "num": 1, "nested": {"text": "café"}}
+    target = tmp_path / "data.json"
+    write_json(data, target.as_posix())
+
+    with target.open(encoding="utf-8") as f:
+        loaded = json.load(f)
+
+    assert loaded == data
+    # Ensure no temporary files remain
+    assert {p.name for p in tmp_path.iterdir()} == {target.name}
+


### PR DESCRIPTION
## Summary
- add atomic `write_json` helper with UTF-8 encoding
- test JSON round-trip serialization and ensure no temp file remains

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a90e47604c8322a5a26110bd5600ab