### PR TITLE
Implement atomic parquet writer

### DIFF
--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,10 +1,12 @@
-from pathlib import Path
-import sys
 import json
+import sys
+from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from mw.utils.persistence import write_json
+import pandas as pd  # noqa: E402
+
+from mw.utils.persistence import write_json, write_parquet  # noqa: E402
 
 
 def test_write_json_round_trip(tmp_path):
@@ -19,3 +21,13 @@ def test_write_json_round_trip(tmp_path):
     # Ensure no temporary files remain
     assert {p.name for p in tmp_path.iterdir()} == {target.name}
 
+
+def test_write_parquet_round_trip(tmp_path):
+    df = pd.DataFrame({"a": [1, 2], "b": ["x", "y"]})
+    target = tmp_path / "nested" / "data.parquet"
+    write_parquet(df, target.as_posix())
+
+    loaded = pd.read_parquet(target)
+    assert loaded.equals(df)
+    # Ensure no temporary files remain
+    assert {p.name for p in (tmp_path / "nested").iterdir()} == {target.name}


### PR DESCRIPTION
## Summary
- add atomic parquet persistence helper with logging
- test parquet round-trip file creation

## Testing
- `pre-commit run --files mw/utils/persistence.py tests/test_persistence.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a90f7463dc8322afbe29113f5cb886