### PR TITLE
Implement UTC time helper and add tests

### DIFF
--- a/mw/utils/time.py
+++ b/mw/utils/time.py
@@ -3,9 +3,10 @@ Time helpers (stub).
 """
 from datetime import datetime, timezone, timedelta
 
+
 def now_utc() -> datetime:
-    # TODO: implement
-    raise NotImplementedError
+    """Return the current time as an aware ``datetime`` in UTC."""
+    return datetime.now(timezone.utc)
 
 def floor_to_minute(dt: datetime) -> datetime:
     # TODO: implement

--- a/tests/test_time_utils.py
+++ b/tests/test_time_utils.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+from datetime import datetime, timezone
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from mw.utils.time import now_utc  # noqa: E402
+
+
+def test_now_utc_timezone_and_proximity():
+    current = now_utc()
+    assert current.tzinfo == timezone.utc
+    system_now = datetime.now(timezone.utc)
+    assert abs((system_now - current).total_seconds()) < 1


### PR DESCRIPTION
## Summary
- implement `now_utc` returning current timezone-aware UTC time
- document `now_utc`
- add tests for timezone awareness and proximity to system time

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a913a9dbc88322be22f44e7a73ee30