### PR TITLE
Implement floor_to_minute and add timezone tests

### DIFF
--- a/mw/utils/time.py
+++ b/mw/utils/time.py
@@ -1,13 +1,17 @@
-"""
-Time helpers (stub).
-"""
-from datetime import datetime, timezone, timedelta
+"""Time helpers."""
+
+from datetime import datetime, timezone
 
 
 def now_utc() -> datetime:
     """Return the current time as an aware ``datetime`` in UTC."""
     return datetime.now(timezone.utc)
 
+
 def floor_to_minute(dt: datetime) -> datetime:
-    # TODO: implement
-    raise NotImplementedError
+    """Return ``dt`` floored to the start of the minute.
+
+    The original timezone information is preserved.
+    """
+
+    return dt.replace(second=0, microsecond=0)

--- a/tests/test_time_utils.py
+++ b/tests/test_time_utils.py
@@ -1,10 +1,12 @@
 import sys
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from datetime import datetime, timezone
+
+import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from mw.utils.time import now_utc  # noqa: E402
+from mw.utils.time import floor_to_minute, now_utc  # noqa: E402
 
 
 def test_now_utc_timezone_and_proximity():
@@ -12,3 +14,39 @@ def test_now_utc_timezone_and_proximity():
     assert current.tzinfo == timezone.utc
     system_now = datetime.now(timezone.utc)
     assert abs((system_now - current).total_seconds()) < 1
+
+
+@pytest.mark.parametrize(
+    "dt_raw, expected_raw",
+    [
+        (
+            datetime(2024, 1, 1, 12, 34, 56, 789),
+            datetime(2024, 1, 1, 12, 34),
+        ),
+        (
+            datetime(2024, 1, 1, 23, 59, 59, 999_999),
+            datetime(2024, 1, 1, 23, 59),
+        ),
+        (
+            datetime(2024, 1, 1, 0, 0, 0, 0),
+            datetime(2024, 1, 1, 0, 0),
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "tz",
+    [
+        None,
+        timezone.utc,
+        timezone(timedelta(hours=-5)),
+        timezone(timedelta(hours=5, minutes=30)),
+    ],
+)
+def test_floor_to_minute_preserves_timezone_and_floors(
+    dt_raw,
+    expected_raw,
+    tz,
+):
+    dt = dt_raw.replace(tzinfo=tz)
+    expected = expected_raw.replace(tzinfo=tz)
+    assert floor_to_minute(dt) == expected


### PR DESCRIPTION
## Summary
- implement `floor_to_minute` to zero seconds and microseconds without losing timezone info
- test `floor_to_minute` across multiple time zones and edge cases

## Testing
- `pre-commit run --files mw/utils/time.py tests/test_time_utils.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a91448f2948322a22fbf843bcb5ed7