### PR TITLE
Implement Rosenstein FTLE with synthetic tests

### DIFF
--- a/mw/features/ftle.py
+++ b/mw/features/ftle.py
@@ -1,24 +1,114 @@
-"""
-Finite-Time Lyapunov Exponent (Rosenstein) (stubs).
+"""Finite-Time Lyapunov Exponent via the Rosenstein method.
 
-Exports:
-- ftle_rosenstein(series: pd.Series, window: int, m: int=3, tau: int=1,
-                  horizon: int=10, theiler: int=2) -> float
-- rolling_ftle_rosenstein(series: pd.Series, window: int, m: int=3, tau: int=1,
-                          horizon: int=10, theiler: int=2) -> pd.Series
-Notes:
-- Delay embedding, nearest neighbor excluding Theiler window,
-  robust slope fit of log distance vs k, median across anchors.
-- Clamp tiny distances with epsilon to avoid -inf.
+Exports
+-------
+ftle_rosenstein
+    Estimate the largest Lyapunov exponent for the last ``window`` points of a
+    series using delay embedding and nearest neighbours.
+rolling_ftle_rosenstein
+    Causal rolling version of :func:`ftle_rosenstein` aligned to window end.
+
+Notes
+-----
+- Delay embedding, nearest neighbour excluding Theiler window, robust slope fit
+  of log distance vs k, median across anchors.
+- Distances are clamped with an ``epsilon`` to avoid ``-inf`` when taking the
+  logarithm.
 """
+
+from __future__ import annotations
+
+from typing import Iterable
+
+import numpy as np
 import pandas as pd
 
-def ftle_rosenstein(series: pd.Series, window: int, m: int = 3, tau: int = 1,
-                    horizon: int = 10, theiler: int = 2) -> float:
-    # TODO: implement
-    raise NotImplementedError
 
-def rolling_ftle_rosenstein(series: pd.Series, window: int, m: int = 3, tau: int = 1,
-                            horizon: int = 10, theiler: int = 2) -> pd.Series:
-    # TODO: implement
-    raise NotImplementedError
+def _delay_embed(x: np.ndarray, m: int, tau: int) -> np.ndarray:
+    """Return m-dimensional delay embedding of ``x`` with delay ``tau``."""
+    n = x.size - (m - 1) * tau
+    if n <= 0:
+        return np.empty((0, m))
+    cols = [x[i : i + n] for i in range(0, m * tau, tau)]  # noqa: E203
+    return np.column_stack(cols)
+
+
+def _slope(y: Iterable[float]) -> float:
+    """Return slope of least-squares fit of ``y`` vs ``1..len(y)``."""
+    x = np.arange(1, len(y) + 1, dtype=float)
+    y = np.asarray(list(y), dtype=float)
+    x_mean = x.mean()
+    y_mean = y.mean()
+    denom = ((x - x_mean) ** 2).sum()
+    if denom == 0:
+        return float("nan")
+    return float(((x - x_mean) * (y - y_mean)).sum() / denom)
+
+
+def ftle_rosenstein(
+    series: pd.Series,
+    window: int,
+    m: int = 3,
+    tau: int = 1,
+    horizon: int = 10,
+    theiler: int = 2,
+) -> float:
+    """Estimate the finite-time Lyapunov exponent using Rosenstein's method.
+
+    Parameters
+    ----------
+    series
+        Input time series. Only the last ``window`` observations are used.
+    window
+        Number of trailing observations to analyse.
+    m, tau
+        Embedding dimension and delay.
+    horizon
+        Forecast horizon ``k`` over which to track divergence.
+    theiler
+        Exclusion window to avoid temporally adjacent points when searching for
+        nearest neighbours.
+    """
+
+    x = series.dropna().to_numpy()[-window:]
+    embed = _delay_embed(x, m, tau)
+    n_vectors = embed.shape[0]
+    if n_vectors <= horizon + 1:
+        return float("nan")
+
+    valid = n_vectors - horizon
+    anchors = embed[:valid]
+    n = anchors.shape[0]
+    slopes = []
+    eps = 1e-8
+
+    for i in range(n):
+        dists = np.linalg.norm(anchors[i] - anchors, axis=1)
+        mask = np.abs(np.arange(n) - i) <= theiler
+        dists[mask] = np.inf
+        j = int(np.argmin(dists))
+        logs = []
+        for k in range(1, horizon + 1):
+            dist = np.linalg.norm(embed[i + k] - embed[j + k])
+            logs.append(np.log(max(dist, eps)))
+        slopes.append(_slope(logs))
+
+    return float(np.nanmedian(slopes))
+
+
+def rolling_ftle_rosenstein(
+    series: pd.Series,
+    window: int,
+    m: int = 3,
+    tau: int = 1,
+    horizon: int = 10,
+    theiler: int = 2,
+) -> pd.Series:
+    """Causal rolling FTLE using Rosenstein's method."""
+
+    def _apply(x: pd.Series) -> float:
+        return ftle_rosenstein(
+            x, window=len(x), m=m, tau=tau, horizon=horizon, theiler=theiler
+        )
+
+    return series.rolling(window, min_periods=window).apply(_apply, raw=False)

--- a/tests/test_ftle.py
+++ b/tests/test_ftle.py
@@ -1,2 +1,39 @@
-def test_placeholder_ftle():
-    assert True
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from mw.features.ftle import ftle_rosenstein  # noqa: E402
+from mw.features.ftle import rolling_ftle_rosenstein  # noqa: E402
+
+
+def logistic_map(r: float, x0: float, n: int) -> np.ndarray:
+    x = np.empty(n)
+    x[0] = x0
+    for i in range(1, n):
+        x[i] = r * x[i - 1] * (1 - x[i - 1])
+    return x
+
+
+def test_ftle_rosenstein_logistic_map():
+    data = logistic_map(4.0, 0.2, 500)
+    series = pd.Series(data)
+    val = ftle_rosenstein(series, window=200, m=2, tau=1, horizon=5, theiler=2)
+    assert val == pytest.approx(np.log(2), abs=0.2)
+
+
+def test_rolling_matches_direct():
+    data = logistic_map(4.0, 0.2, 300)
+    series = pd.Series(data)
+    window = 100
+    rolling = rolling_ftle_rosenstein(
+        series, window=window, m=2, tau=1, horizon=5, theiler=2
+    )
+    direct = ftle_rosenstein(
+        series.iloc[-window:], window=window, m=2, tau=1, horizon=5, theiler=2
+    )
+    assert rolling.iloc[-1] == pytest.approx(direct)


### PR DESCRIPTION
## Summary
- implement Rosenstein-based finite-time Lyapunov exponent with delay embedding, Theiler exclusion and median slope
- add rolling FTLE helper and tests using logistic map data

## Testing
- `pre-commit run --files mw/features/ftle.py tests/test_ftle.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9154d49448322b512a72d4873dae0