### PR TITLE
Implement causal min-max scaling with tests

### DIFF
--- a/mw/features/scaling.py
+++ b/mw/features/scaling.py
@@ -3,20 +3,48 @@ Scaling & normalization (stubs).
 
 Exports:
 - minmax_causal(x: pd.Series, win: int) -> pd.Series in [0,1]
-- tod_percentile_fit(x: pd.Series) -> dict      # minute-of-day profiles (offline)
+- tod_percentile_fit(x: pd.Series) -> dict
+  # minute-of-day profiles (offline)
 - tod_percentile_transform(x: pd.Series, model: dict) -> pd.Series in [0,1]
 """
+
 import pandas as pd
 
-def minmax_causal(x: pd.Series, win: int) -> pd.Series:
-    """Causal min-max scaling over trailing window `win`."""
-    # TODO: implement (rolling min/max; protect divide-by-zero)
-    raise NotImplementedError
+
+def minmax_causal(x: pd.Series, win: int, eps: float = 1e-9) -> pd.Series:
+    """Causal min-max scaling over a trailing window.
+
+    Parameters
+    ----------
+    x
+        Input series to scale.
+    win
+        Size of the trailing window used for the min/max calculation.
+    eps
+        Small constant added to the denominator to avoid division by zero when
+        the windowed range is constant.
+
+    Returns
+    -------
+    pd.Series
+        Series normalised to the ``[0, 1]`` range.
+    """
+
+    if win <= 0:
+        raise ValueError("win must be positive")
+
+    roll = x.rolling(win, min_periods=1)
+    x_min = roll.min()
+    x_max = roll.max()
+    scaled = (x - x_min) / (x_max - x_min + eps)
+    return scaled.clip(0.0, 1.0)
+
 
 def tod_percentile_fit(x: pd.Series) -> dict:
     """Fit time-of-day percentile references (offline)."""
     # TODO: implement
     raise NotImplementedError
+
 
 def tod_percentile_transform(x: pd.Series, model: dict) -> pd.Series:
     """Map values to [0,1] by minute-of-day percentiles."""

--- a/tests/test_scaling.py
+++ b/tests/test_scaling.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from mw.features.scaling import minmax_causal  # noqa: E402
+
+
+def test_minmax_causal_scales_to_unit_interval():
+    x = pd.Series([0, 5, 3, 4])
+    result = minmax_causal(x, win=3)
+    expected = pd.Series([0, 1, 0.6, 0.5])
+    assert result.tolist() == pytest.approx(expected.tolist())
+    assert result.between(0, 1).all()
+
+
+def test_minmax_causal_constant_series():
+    x = pd.Series([2, 2, 2])
+    result = minmax_causal(x, win=2)
+    assert result.eq(0).all()


### PR DESCRIPTION
## Summary
- implement `minmax_causal` using rolling min/max and epsilon-safe normalisation
- add unit tests to verify scaling and constant-window behaviour

## Testing
- `pre-commit run --files mw/features/scaling.py tests/test_scaling.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a917406e088322bf885808b5c93142