### PR TITLE
Handle missing time-of-day percentile entries

### DIFF
--- a/mw/features/scaling.py
+++ b/mw/features/scaling.py
@@ -87,7 +87,8 @@ def tod_percentile_transform(
     Returns
     -------
     pd.Series
-        Series of percentile scores in ``[0, 1]``.
+        Series of percentile scores in ``[0, 1]``. Minutes not present in the
+        ``model`` yield ``NaN`` values instead of raising ``KeyError``.
     """
 
     if not isinstance(x.index, pd.DatetimeIndex):

--- a/tests/test_scaling.py
+++ b/tests/test_scaling.py
@@ -58,3 +58,14 @@ def test_tod_percentile_transform_computes_percentiles():
     expected = pd.Series([0.5, 0.5, 1.0], index=idx)
     assert result.tolist() == pytest.approx(expected.tolist())
     assert result.between(0, 1).all()
+
+
+def test_tod_percentile_transform_handles_missing_minutes():
+    """Missing model entries should produce NaNs instead of errors."""
+    model = {0: np.array([1, 3])}  # minute 1 deliberately absent
+    idx = pd.to_datetime(["2024-01-03 00:00", "2024-01-03 00:01"])
+    x = pd.Series([2, 3], index=idx)
+    result = tod_percentile_transform(x, model)
+
+    assert result.iloc[0] == pytest.approx(0.5)
+    assert np.isnan(result.iloc[1])


### PR DESCRIPTION
## Summary
- Clarify tod_percentile_transform docs on NaN returns for missing minutes
- Add regression test ensuring missing time-of-day model entries yield NaN

## Testing
- `pre-commit run --files mw/features/scaling.py tests/test_scaling.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9191c63d483228c26a1133a101041