### PR TITLE
Implement permutation entropy with validation tests

### DIFF
--- a/mw/features/entropy.py
+++ b/mw/features/entropy.py
@@ -3,26 +3,76 @@ Entropy metrics (stubs).
 
 Exports (to implement):
 - permutation_entropy(series: pd.Series, m=3, tau=1) -> float
-- rolling_permutation_entropy(series: pd.Series, window: int, m=3, tau=1) -> pd.Series
+- rolling_permutation_entropy(
+    series: pd.Series, window: int, m=3, tau=1
+  ) -> pd.Series
 - sample_entropy(series: pd.Series, m=2, r=0.2) -> float
 Notes:
 - Use closes or returns; causal windows only.
 - Handle ties by tiny jitter or averaged ranks.
 """
-from typing import Optional
+
+from collections import Counter
+from math import factorial, log
+from typing import List, Tuple
+
+import numpy as np
 import pandas as pd
 
-def permutation_entropy(series: pd.Series, m: int = 3, tau: int = 1) -> float:
-    """Return normalized permutation entropy in [0,1] for the last window of `series`."""
-    # TODO: implement (ordinal patterns -> frequencies -> normalized entropy)
-    raise NotImplementedError
 
-def rolling_permutation_entropy(series: pd.Series, window: int, m: int = 3, tau: int = 1) -> pd.Series:
+def _ordinal_patterns(
+    values: np.ndarray,
+    m: int,
+    tau: int,
+) -> List[Tuple[int, ...]]:
+    """Return ordinal patterns for ``values``."""
+    n = len(values)
+    if n < (m - 1) * tau + 1:
+        return []
+
+    patterns: List[Tuple[int, ...]] = []
+    for i in range(n - (m - 1) * tau):
+        window = values[i : i + (m - 1) * tau + 1 : tau]  # noqa: E203
+        inner = np.argsort(window, kind="mergesort")
+        ranks = np.argsort(inner, kind="mergesort")
+        patterns.append(tuple(ranks))
+    return patterns
+
+
+def permutation_entropy(series: pd.Series, m: int = 3, tau: int = 1) -> float:
+    """Return normalized permutation entropy in [0,1] for the last window of
+    ``series``.
+    """
+    values = series.dropna().to_numpy()
+    patterns = _ordinal_patterns(values, m, tau)
+    if not patterns:
+        return float("nan")
+
+    counts = Counter(patterns)
+    probs = np.fromiter(counts.values(), dtype=float)
+    probs /= probs.sum()
+    entropy = -np.sum(probs * np.log(probs))
+    return float(entropy / log(factorial(m)))
+
+
+def rolling_permutation_entropy(
+    series: pd.Series, window: int, m: int = 3, tau: int = 1
+) -> pd.Series:
     """Causal rolling PE; aligns result to window end."""
-    # TODO: implement
-    raise NotImplementedError
+
+    def _pe(x: np.ndarray) -> float:
+        return permutation_entropy(pd.Series(x), m=m, tau=tau)
+
+    return series.rolling(window, min_periods=window).apply(
+        _pe,
+        raw=True,
+    )
+
 
 def sample_entropy(series: pd.Series, m: int = 2, r: float = 0.2) -> float:
-    """Return Sample Entropy for the last window of `series` (use robust sigma for r*sigma)."""
+    """Return Sample Entropy for the last window of `series`.
+
+    Uses robust sigma for r*sigma.
+    """
     # TODO: implement (with Theiler exclusion)
     raise NotImplementedError

--- a/tests/test_entropy.py
+++ b/tests/test_entropy.py
@@ -1,2 +1,25 @@
-def test_placeholder_entropy():
-    assert True
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from mw.features.entropy import permutation_entropy  # noqa: E402
+
+
+def test_monotonic_series_has_zero_entropy():
+    series = pd.Series(range(10))
+    assert permutation_entropy(series, m=3, tau=1) == 0.0
+
+
+def test_constant_series_has_zero_entropy():
+    series = pd.Series([5] * 10)
+    assert permutation_entropy(series, m=3, tau=1) == 0.0
+
+
+def test_random_series_has_high_entropy():
+    rng = np.random.default_rng(0)
+    series = pd.Series(rng.normal(size=1000))
+    h = permutation_entropy(series, m=3, tau=1)
+    assert h > 0.95


### PR DESCRIPTION
## Summary
- implement ordinal pattern generation and normalized permutation entropy
- add rolling permutation entropy utility
- add tests validating entropy on monotonic, constant, and random signals

## Testing
- `pre-commit run --files mw/features/entropy.py tests/test_entropy.py`
- `pytest tests/test_entropy.py`


------
https://chatgpt.com/codex/tasks/task_e_68a919e9892c83228bb860a5ec1d2e8a