### PR TITLE
Implement causal EMA helper and tests

### DIFF
--- a/mw/features/smoothing.py
+++ b/mw/features/smoothing.py
@@ -6,7 +6,22 @@ Exports:
 """
 import pandas as pd
 
+
 def ema(series: pd.Series, span: int = 3) -> pd.Series:
-    """Simple exponential moving average (causal)."""
-    # TODO: implement (use pandas ewm with adjust=False)
-    raise NotImplementedError
+    """Simple exponential moving average (causal).
+
+    Parameters
+    ----------
+    series : pd.Series
+        Input data.
+    span : int, default 3
+        Span parameter for the EMA.
+
+    Returns
+    -------
+    pd.Series
+        Exponentially weighted moving average aligned with the input index.
+    """
+
+    result = series.ewm(span=span, adjust=False).mean()
+    return result.loc[series.index]

--- a/tests/test_smoothing.py
+++ b/tests/test_smoothing.py
@@ -1,0 +1,35 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from mw.features.smoothing import ema  # noqa: E402  # isort: skip
+
+
+def manual_ema(series: pd.Series, span: int) -> pd.Series:
+    alpha = 2 / (span + 1)
+    vals = []
+    for x in series:
+        if not vals:
+            vals.append(x)
+        else:
+            vals.append(alpha * x + (1 - alpha) * vals[-1])
+    return pd.Series(vals, index=series.index)
+
+
+def test_ema_matches_manual_calculation_and_preserves_index():
+    idx = pd.to_datetime(
+        ["2024-01-01", "2024-01-02", "2024-01-03", "2024-01-04"]
+    )
+    x = pd.Series([1.0, 2.0, 3.0, 4.0], index=idx)
+    span = 3
+
+    result = ema(x, span=span)
+    expected = manual_ema(x, span)
+
+    assert result.index.equals(x.index)
+    assert result.tolist() == pytest.approx(expected.tolist())
+


### PR DESCRIPTION
## Summary
- add exponential moving average helper using `Series.ewm(span, adjust=False)`
- ensure EMA output aligns with input index
- add unit test comparing EMA with manual calculation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a91ddb71848322941add093d82c528