### PR TITLE
Implement minute loop orchestration with scheduling and tests

### DIFF
--- a/mw/live/minute_loop.py
+++ b/mw/live/minute_loop.py
@@ -1,14 +1,54 @@
-"""
-Live minute loop (stub).
+"""Live minute loop orchestration.
 
-Orchestrates: poll -> canonical append -> compute -> score -> state -> log -> plot.
-This module should NOT depend on Colab specifics; pure Python orchestrator.
-"""
-from typing import Callable, Dict, Any
+This module coordinates the high level steps executed every minute:
 
-def run_minute_loop(poll_fn: Callable, compute_fn: Callable,
-                    persist_fn: Callable, plot_fn: Callable,
-                    health_fn: Callable, params: Dict[str, Any]) -> None:
-    """High-level loop; call every minute (t+3s)."""
-    # TODO: implement skeleton orchestration
-    raise NotImplementedError
+``poll -> compute -> persist -> plot -> health``.
+
+The function waits for configured offsets from the start of the current
+minute before invoking each step so that calls are synchronised with
+minute boundaries.  Offsets (in seconds) are supplied via ``params`` and
+default to a small stagger between steps.
+"""
+
+import time
+from datetime import timedelta
+from typing import Any, Callable, Dict
+
+from mw.utils.time import floor_to_minute, now_utc
+
+
+def run_minute_loop(
+    poll_fn: Callable,
+    compute_fn: Callable,
+    persist_fn: Callable,
+    plot_fn: Callable,
+    health_fn: Callable,
+    params: Dict[str, Any],
+) -> None:
+    """High-level loop; call every minute (t+3s).
+
+    The supplied callables are invoked sequentially with waits applied
+    before each invocation to honour per-step offsets from the start of
+    the current minute.
+    """
+
+    offsets = params.get(
+        "minute_loop_offsets",
+        {"poll": 3, "compute": 5, "persist": 6, "plot": 7, "health": 8},
+    )
+
+    minute_start = floor_to_minute(now_utc())
+
+    steps = [
+        ("poll", poll_fn),
+        ("compute", compute_fn),
+        ("persist", persist_fn),
+        ("plot", plot_fn),
+        ("health", health_fn),
+    ]
+
+    for name, fn in steps:
+        target = minute_start + timedelta(seconds=offsets.get(name, 0))
+        sleep_for = (target - now_utc()).total_seconds()
+        time.sleep(max(0.0, sleep_for))
+        fn()

--- a/tests/test_minute_loop.py
+++ b/tests/test_minute_loop.py
@@ -1,0 +1,54 @@
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from mw.live.minute_loop import run_minute_loop  # noqa: E402
+
+
+def test_run_minute_loop_calls_functions_in_order(monkeypatch):
+    call_order = []
+
+    def mk(name):
+        return lambda: call_order.append(name)
+
+    poll = mk("poll")
+    compute = mk("compute")
+    persist = mk("persist")
+    plot = mk("plot")
+    health = mk("health")
+
+    sleeps = []
+    monkeypatch.setattr("time.sleep", lambda x: sleeps.append(x))
+
+    start = datetime(2024, 1, 1, 0, 0, 2, tzinfo=timezone.utc)
+    times_iter = iter(
+        [
+            start,
+            start,
+            start + timedelta(seconds=2),
+            start + timedelta(seconds=5),
+            start + timedelta(seconds=6),
+            start + timedelta(seconds=7),
+        ]
+    )
+    monkeypatch.setattr(
+        "mw.live.minute_loop.now_utc",
+        lambda: next(times_iter),
+    )
+
+    params = {
+        "minute_loop_offsets": {
+            "poll": 3,
+            "compute": 6,
+            "persist": 7,
+            "plot": 8,
+            "health": 9,
+        }
+    }
+
+    run_minute_loop(poll, compute, persist, plot, health, params)
+
+    assert call_order == ["poll", "compute", "persist", "plot", "health"]
+    assert sleeps == [1.0, 2.0, 0.0, 0.0, 0.0]


### PR DESCRIPTION
## Summary
- implement minute loop coordinator that waits for per-step offsets
- add tests verifying call order and timing via mocks

## Testing
- `pre-commit run --files mw/live/minute_loop.py tests/test_minute_loop.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a91e735ed0832289db0d3076723f47