### PR TITLE
Add freshness computation and tests

### DIFF
--- a/mw/live/health.py
+++ b/mw/live/health.py
@@ -1,16 +1,38 @@
-"""
-Health & freshness (stub).
+"""Health & freshness utilities.
 
 Exports:
 - compute_freshness(last_bar_ts) -> float seconds
-- should_degrade(freshness_s: float, thresh: float=180) -> bool
+- should_degrade(freshness_s: float, thresh: float = 180) -> bool
 """
-from datetime import datetime, timezone
 
-def compute_freshness(last_bar_ts: datetime) -> float:
-    # TODO: implement
-    raise NotImplementedError
+from datetime import datetime, timezone
+from typing import Optional
+
+
+def compute_freshness(last_bar_ts: Optional[datetime]) -> float:
+    """Return seconds since ``last_bar_ts``.
+
+    ``last_bar_ts`` is expected to be an aware ``datetime`` in UTC. If the
+    timestamp is missing ``float('inf')`` is returned. The calculation uses the
+    current UTC time.
+    """
+
+    if last_bar_ts is None:
+        return float("inf")
+
+    now = datetime.now(timezone.utc)
+    return (now - last_bar_ts).total_seconds()
+
 
 def should_degrade(freshness_s: float, thresh: float = 180.0) -> bool:
-    # TODO: implement
-    raise NotImplementedError
+    """Return ``True`` when ``freshness_s`` exceeds ``thresh``.
+
+    Parameters
+    ----------
+    freshness_s: float
+        Age of the last data point in seconds.
+    thresh: float
+        Threshold in seconds before degradation should occur.
+    """
+
+    return freshness_s >= thresh

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,17 @@
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+from mw.live.health import compute_freshness
+
+
+def test_compute_freshness_elapsed_seconds():
+    now = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    last_bar = datetime(2023, 1, 1, 11, 59, 0, tzinfo=timezone.utc)
+    with patch("mw.live.health.datetime") as mock_datetime:
+        mock_datetime.now.return_value = now
+        result = compute_freshness(last_bar)
+    assert result == 60.0
+
+
+def test_compute_freshness_missing_timestamp():
+    assert compute_freshness(None) == float("inf")


### PR DESCRIPTION
## Summary
- compute freshness in seconds compared to current UTC
- degrade when freshness exceeds threshold
- test freshness calculations with patched datetime and missing timestamps

## Testing
- `pre-commit run --files mw/live/health.py tests/test_health.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a91fbd1fe08322b7659b33795b4dba