### PR TITLE
Use strict freshness threshold

### DIFF
--- a/mw/live/health.py
+++ b/mw/live/health.py
@@ -32,7 +32,9 @@ def should_degrade(freshness_s: float, thresh: float = 180.0) -> bool:
     freshness_s: float
         Age of the last data point in seconds.
     thresh: float
-        Threshold in seconds before degradation should occur.
+        Threshold in seconds before degradation should occur. The default of
+        ``180`` seconds (three minutes) represents the service's acceptable age
+        for data before degradation.
     """
 
-    return freshness_s >= thresh
+    return freshness_s > thresh

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,7 +1,9 @@
 from datetime import datetime, timezone
 from unittest.mock import patch
 
-from mw.live.health import compute_freshness
+import pytest
+
+from mw.live.health import compute_freshness, should_degrade
 
 
 def test_compute_freshness_elapsed_seconds():
@@ -15,3 +17,15 @@ def test_compute_freshness_elapsed_seconds():
 
 def test_compute_freshness_missing_timestamp():
     assert compute_freshness(None) == float("inf")
+
+
+@pytest.mark.parametrize(
+    "freshness, expected",
+    [
+        (179.0, False),
+        (180.0, False),
+        (181.0, True),
+    ],
+)
+def test_should_degrade_threshold_boundary(freshness, expected):
+    assert should_degrade(freshness) is expected


### PR DESCRIPTION
## Summary
- require freshness to be strictly greater than the degradation threshold
- document default threshold of 180 seconds (3 minutes)
- add boundary tests to ensure degradation only occurs above the threshold

## Testing
- `pre-commit run --files mw/live/health.py tests/test_health.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9209aa5448322ac130b694e667d6e