### PR TITLE
Implement canonicalizer for OHLC data with integrity checks

### DIFF
--- a/mw/io/canonicalizer.py
+++ b/mw/io/canonicalizer.py
@@ -1,9 +1,130 @@
-"""Canonicalizer (placeholder).
+"""Canonicalize raw OHLCV data.
 
-Responsibilities:
-- Convert ET -> UTC, set strict 1-min grid
-- Mark gaps, keep duplicates-last
-- OHLC integrity checks
-- Persist Parquet + .meta.json (hashes, counts, contract_version)
+This module normalises raw minute level market data so that downstream
+components can rely on a stable contract.  The process consists of:
+
+* converting timestamps from Eastern time to UTC;
+* enforcing a strict one minute grid, keeping only the last observation
+  when duplicates are present and inserting explicit gap rows when data is
+  missing;
+* validating the ``open``, ``high``, ``low`` and ``close`` relationship for
+  every observation; and
+* persisting the result as a Parquet file accompanied by a ``.meta.json``
+  file containing basic integrity information.
+
+The entry point is :func:`canonicalize` which accepts a dataframe and a
+target Parquet path.  The function writes the canonicalised data and returns
+the dataframe for convenience.
 """
-# TODO: implement
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Dict
+
+import pandas as pd
+import pytz
+
+from mw.utils.ohlc_checks import validate_ohlc
+from mw.utils.persistence import write_json, write_parquet
+
+
+ET_TZ = pytz.timezone("America/New_York")
+
+
+def _hash_df(df: pd.DataFrame) -> str:
+    """Return a deterministic SHA256 hash for ``df``.
+
+    The dataframe is hashed row wise using :func:`pandas.util.hash_pandas_object`
+    which provides a stable 64bit hash for each row.  The bytes of these hashes
+    are then digested with SHA256 to obtain the final hexadecimal string.
+    """
+
+    row_hashes = pd.util.hash_pandas_object(df, index=True).values.tobytes()
+    return hashlib.sha256(row_hashes).hexdigest()
+
+
+def canonicalize(
+    df: pd.DataFrame, parquet_path: str, contract_version: int = 1
+) -> pd.DataFrame:
+    """Canonicalise ``df`` and persist the result to ``parquet_path``.
+
+    Parameters
+    ----------
+    df:
+        Raw market data.  Must contain ``timestamp`` along with the OHLC
+        columns ``open``, ``high``, ``low`` and ``close``.  Timestamps are
+        interpreted as Eastern time if naive.
+    parquet_path:
+        Destination path for the parquet file.  A sibling ``.meta.json`` will
+        be written alongside it containing metadata about the canonicalised
+        dataset.
+    contract_version:
+        Integer identifying the schema version of the canonical contract.
+
+    Returns
+    -------
+    pd.DataFrame
+        The canonicalised dataframe with a UTC ``timestamp`` index and an
+        ``is_gap`` column indicating missing minutes.
+    """
+
+    working = df.copy()
+
+    # ------------------------------------------------------------------
+    # Timestamp normalisation
+    ts = pd.to_datetime(working["timestamp"])
+    if ts.dt.tz is None:
+        ts = ts.dt.tz_localize(ET_TZ)
+    else:
+        ts = ts.dt.tz_convert(ET_TZ)
+    ts = ts.dt.tz_convert("UTC")
+    working["timestamp"] = ts
+
+    # Sort and remove duplicate timestamps, keeping the last observation.
+    working = working.sort_values("timestamp")
+    duplicate_count = int(working["timestamp"].duplicated(keep="last").sum())
+    working = working.drop_duplicates(subset="timestamp", keep="last")
+
+    # ------------------------------------------------------------------
+    # OHLC integrity checks
+    ohlc_cols = ["open", "high", "low", "close"]
+    valid_mask = validate_ohlc(working[ohlc_cols])
+    if not bool(valid_mask.all()):
+        raise ValueError("Invalid OHLC row detected")
+
+    # ------------------------------------------------------------------
+    # Enforce strict one-minute grid and mark gaps
+    working = working.set_index("timestamp")
+    full_index = pd.date_range(
+        start=working.index.min(),
+        end=working.index.max(),
+        freq="1min",
+        tz="UTC",
+    )
+    working = working.reindex(full_index)
+
+    gap_mask = working[ohlc_cols].isna().all(axis=1)
+    working["is_gap"] = gap_mask
+    gap_count = int(gap_mask.sum())
+
+    # ------------------------------------------------------------------
+    # Metadata and persistence
+    metadata: Dict[str, Any] = {
+        "rows": int(len(working)),
+        "duplicates": duplicate_count,
+        "gaps": gap_count,
+        "contract_version": contract_version,
+    }
+    metadata["hash"] = _hash_df(working)
+
+    # Write parquet and metadata JSON atomically
+    out_df = working.reset_index().rename(columns={"index": "timestamp"})
+    write_parquet(out_df, parquet_path)
+    write_json(metadata, f"{parquet_path}.meta.json")
+
+    return working
+
+
+__all__ = ["canonicalize"]
+

--- a/tests/test_canonicalizer.py
+++ b/tests/test_canonicalizer.py
@@ -1,0 +1,82 @@
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from mw.io.canonicalizer import canonicalize  # noqa: E402
+
+
+def make_sample_df():
+    return pd.DataFrame(
+        {
+            "timestamp": [
+                "2024-01-01 09:30",
+                "2024-01-01 09:31",
+                "2024-01-01 09:31",  # duplicate
+                "2024-01-01 09:33",  # gap at 09:32
+            ],
+            "open": [10.0, 10.5, 10.6, 11.0],
+            "high": [11.0, 11.5, 11.6, 12.0],
+            "low": [9.0, 10.0, 10.1, 10.5],
+            "close": [10.5, 11.0, 11.1, 11.5],
+        }
+    )
+
+
+def test_canonicalize_end_to_end(tmp_path):
+    raw = make_sample_df()
+    out = tmp_path / "data.parquet"
+    canonicalize(raw, out.as_posix())
+
+    result = pd.read_parquet(out)
+    result["timestamp"] = pd.to_datetime(result["timestamp"], utc=True)
+
+    expected_index = pd.date_range(
+        "2024-01-01 14:30", periods=4, freq="1min", tz="UTC"
+    )
+    expected = pd.DataFrame(
+        {
+            "timestamp": expected_index,
+            "open": [10.0, 10.6, float("nan"), 11.0],
+            "high": [11.0, 11.6, float("nan"), 12.0],
+            "low": [9.0, 10.1, float("nan"), 10.5],
+            "close": [10.5, 11.1, float("nan"), 11.5],
+            "is_gap": [False, False, True, False],
+        }
+    )
+
+    pd.testing.assert_frame_equal(result, expected)
+
+    meta_path = Path(str(out) + ".meta.json")
+    with meta_path.open() as f:
+        meta = json.load(f)
+
+    assert meta["rows"] == 4
+    assert meta["duplicates"] == 1
+    assert meta["gaps"] == 1
+    assert meta["contract_version"] == 1
+    assert isinstance(meta["hash"], str) and len(meta["hash"]) == 64
+
+
+def test_canonicalize_invalid_ohlc(tmp_path):
+    bad = pd.DataFrame(
+        {
+            "timestamp": ["2024-01-01 09:30"],
+            "open": [1.0],
+            "high": [1.0],
+            "low": [2.0],  # invalid low > high
+            "close": [1.0],
+        }
+    )
+    out = tmp_path / "bad.parquet"
+
+    with pytest.raises(ValueError):
+        canonicalize(bad, out.as_posix())
+
+    assert not out.exists()
+    assert not Path(str(out) + ".meta.json").exists()
+


### PR DESCRIPTION
## Summary
- Add full canonicalization pipeline converting ET timestamps to UTC, enforcing 1‑minute grid, dropping duplicate bars and marking gaps
- Validate OHLC integrity and persist parquet with accompanying metadata JSON including hashes and counts
- Add integration tests covering canonicalization and failure on invalid OHLC input

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9216684fc8322b3eb91caacc8126a