### PR TITLE
Add diagnostic subplot visualization and tests

### DIFF
--- a/mw/viz/plots.py
+++ b/mw/viz/plots.py
@@ -1,14 +1,47 @@
-"""
-Visualization (stubs).
+"""Visualization utilities.
 
 Exports:
 - plot_price_with_state(df, state_series) -> figure
 - plot_diagnostics(e_hat, l_hat, score) -> figure
 """
+
+from matplotlib import pyplot as plt
+import pandas as pd
+
+
 def plot_price_with_state(df, state_series):
     # TODO: implement (matplotlib; background shading by state)
     raise NotImplementedError
 
-def plot_diagnostics(e_hat, l_hat, score):
-    # TODO: implement (three aligned axes)
-    raise NotImplementedError
+
+def plot_diagnostics(e_hat: pd.Series, l_hat: pd.Series, score: pd.Series):
+    """Plot diagnostic series on three vertically aligned subplots.
+
+    Parameters
+    ----------
+    e_hat : pd.Series
+        Error series to plot on the first subplot.
+    l_hat : pd.Series
+        Leakage series to plot on the second subplot.
+    score : pd.Series
+        Score series to plot on the third subplot.
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+        Figure containing three aligned subplots with a shared x-axis.
+    """
+
+    fig, axes = plt.subplots(3, 1, sharex=True)
+
+    axes[0].plot(e_hat)
+    axes[1].plot(l_hat)
+    axes[2].plot(score)
+
+    axes[0].set_ylabel("e_hat")
+    axes[1].set_ylabel("l_hat")
+    axes[2].set_ylabel("score")
+    axes[2].set_xlabel("index")
+
+    return fig
+

--- a/tests/test_plot_diagnostics.py
+++ b/tests/test_plot_diagnostics.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from mw.viz.plots import plot_diagnostics
+
+
+def test_plot_diagnostics_subplots_and_labels():
+    e_hat = pd.Series([0.1, 0.2, 0.3])
+    l_hat = pd.Series([0.2, 0.3, 0.4])
+    score = pd.Series([0.3, 0.4, 0.5])
+
+    fig = plot_diagnostics(e_hat, l_hat, score)
+
+    try:
+        assert len(fig.axes) == 3
+        assert fig.axes[0].get_ylabel() == "e_hat"
+        assert fig.axes[1].get_ylabel() == "l_hat"
+        assert fig.axes[2].get_ylabel() == "score"
+        assert fig.axes[2].get_xlabel() == "index"
+        assert fig.axes[0].get_shared_x_axes().joined(fig.axes[0], fig.axes[1])
+        assert fig.axes[0].get_shared_x_axes().joined(fig.axes[0], fig.axes[2])
+    finally:
+        fig.clf()


### PR DESCRIPTION
## Summary
- implement `plot_diagnostics` to create three vertically aligned subplots with shared x-axis and axis labels
- add tests ensuring the diagnostic plot has correct subplot count, labels, and shared axes

## Testing
- `pytest tests/test_plot_diagnostics.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a922b969a08322afb963e290cf34ea