### PR TITLE
feat: add price plotting with state shading

### DIFF
--- a/mw/viz/plots.py
+++ b/mw/viz/plots.py
@@ -5,13 +5,57 @@ Exports:
 - plot_diagnostics(e_hat, l_hat, score) -> figure
 """
 
-from matplotlib import pyplot as plt
 import pandas as pd
+from matplotlib import pyplot as plt
 
 
-def plot_price_with_state(df, state_series):
-    # TODO: implement (matplotlib; background shading by state)
-    raise NotImplementedError
+def plot_price_with_state(df: pd.DataFrame, state_series: pd.Series):
+    """Plot price with background colored by state.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame containing a ``price`` column or single column of prices.
+    state_series : pd.Series
+        Series of state labels aligned to ``df``'s index. Consecutive regions
+        with the same label are shaded with the same color.
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+        Figure containing a single axes with the price line and state shading.
+    """
+
+    # Ensure alignment and extract the price series
+    states = state_series.reindex(df.index)
+    price = df["price"] if "price" in df.columns else df.iloc[:, 0]
+
+    fig, ax = plt.subplots()
+    ax.plot(df.index, price)
+    ax.set_ylabel("price")
+
+    # Map each distinct state to a color from the matplotlib color cycle
+    color_cycle = plt.rcParams["axes.prop_cycle"].by_key()["color"]
+    state_colors = {
+        state: color_cycle[i % len(color_cycle)]
+        for i, state in enumerate(pd.unique(states.dropna()))
+    }
+
+    # Group consecutive identical states and shade the corresponding regions
+    groups = (states != states.shift()).cumsum()
+    for _, g in states.groupby(groups):
+        state = g.iloc[0]
+        if pd.isna(state):
+            continue
+        start = g.index[0]
+        end = g.index[-1]
+        # Extend the shading to the next index to avoid gaps
+        next_pos = df.index.get_indexer([end])[0] + 1
+        if next_pos < len(df.index):
+            end = df.index[next_pos]
+        ax.axvspan(start, end, color=state_colors[state], alpha=0.3)
+
+    return fig
 
 
 def plot_diagnostics(e_hat: pd.Series, l_hat: pd.Series, score: pd.Series):
@@ -44,4 +88,3 @@ def plot_diagnostics(e_hat: pd.Series, l_hat: pd.Series, score: pd.Series):
     axes[2].set_xlabel("index")
 
     return fig
-

--- a/tests/test_plot_price_with_state.py
+++ b/tests/test_plot_price_with_state.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+import matplotlib
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+matplotlib.use("Agg")
+
+from mw.viz.plots import plot_price_with_state  # noqa: E402
+
+
+def test_plot_price_with_state_line_and_patches():
+    df = pd.DataFrame({"price": [1, 2, 3, 4]}, index=[0, 1, 2, 3])
+    states = pd.Series(["A", "A", "B", "B"], index=df.index)
+
+    fig = plot_price_with_state(df, states)
+    try:
+        ax = fig.axes[0]
+        assert ax.lines[0].get_ydata().tolist() == [1, 2, 3, 4]
+        assert len(ax.patches) == 2
+        # ensure different states produce different colors
+        colors = {tuple(p.get_facecolor()) for p in ax.patches}
+        assert len(colors) == 2
+    finally:
+        fig.clf()


### PR DESCRIPTION
## Summary
- implement price plotting with background shading by state
- test price plot function using a non-interactive backend

## Testing
- `pre-commit run --files mw/viz/plots.py tests/test_plot_price_with_state.py`
- `pytest tests/test_plot_diagnostics.py tests/test_plot_price_with_state.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9235b3ae48322acd6753f0c0f865f