### PR TITLE
Implement tradability score and add tests

### DIFF
--- a/mw/scoring/tradability.py
+++ b/mw/scoring/tradability.py
@@ -16,8 +16,17 @@ DEFAULT_HYST = {"k_up": 2, "k_down": 1, "min_flip_spacing": 3}
 
 def score_tradability(e_hat: pd.Series, l_hat: pd.Series, weights: dict = None) -> pd.Series:
     """𝒯 = w1*(1 - e_hat) + w2*(1 - l_hat), clipped to [0,1]."""
-    # TODO: implement (align indexes; clip)
-    raise NotImplementedError
+    if weights is None:
+        weights = DEFAULT_WEIGHTS
+    else:
+        # fall back to defaults if keys missing
+        weights = {"w1": weights.get("w1", DEFAULT_WEIGHTS["w1"]),
+                   "w2": weights.get("w2", DEFAULT_WEIGHTS["w2"])}
+
+    e_hat_aligned, l_hat_aligned = e_hat.align(l_hat, join="inner")
+
+    score = weights["w1"] * (1 - e_hat_aligned) + weights["w2"] * (1 - l_hat_aligned)
+    return score.clip(0, 1)
 
 def state_machine(scores: pd.Series, prev_state: Optional[str] = None,
                   thresholds: dict = None, hysteresis: dict = None,

--- a/tests/test_tradability.py
+++ b/tests/test_tradability.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from mw.scoring.tradability import score_tradability
+
+
+def test_score_tradability_default_weights_align_and_clip():
+    e_hat = pd.Series([0.1, 0.2, 0.3], index=[0, 1, 2])
+    l_hat = pd.Series([0.4, 0.5, 0.6], index=[1, 2, 3])
+    expected = pd.Series([0.72, 0.62], index=[1, 2])
+
+    result = score_tradability(e_hat, l_hat)
+
+    pd.testing.assert_series_equal(result, expected)
+
+
+def test_score_tradability_custom_weights_and_clip():
+    e_hat = pd.Series([-0.5, 2.0])
+    l_hat = pd.Series([-0.5, 2.0])
+    weights = {"w1": 0.5, "w2": 0.5}
+    expected = pd.Series([1.0, 0.0])
+
+    result = score_tradability(e_hat, l_hat, weights)
+
+    pd.testing.assert_series_equal(result, expected)


### PR DESCRIPTION
## Summary
- compute tradability score as weighted combination of `e_hat` and `l_hat`
- add unit tests for default and custom weight configurations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a923c36bc88322b4e17a67648c4a21