### PR TITLE
Clarify module docstrings for existing helpers

### DIFF
--- a/mw/features/entropy.py
+++ b/mw/features/entropy.py
@@ -1,15 +1,11 @@
-"""
-Entropy metrics (stubs).
+"""Entropy metrics for time series.
 
-Exports (to implement):
+Exports:
 - permutation_entropy(series: pd.Series, m=3, tau=1) -> float
 - rolling_permutation_entropy(
     series: pd.Series, window: int, m=3, tau=1
   ) -> pd.Series
 - sample_entropy(series: pd.Series, m=2, r=0.2) -> float
-Notes:
-- Use closes or returns; causal windows only.
-- Handle ties by tiny jitter or averaged ranks.
 """
 
 from collections import Counter

--- a/mw/features/smoothing.py
+++ b/mw/features/smoothing.py
@@ -1,8 +1,7 @@
-"""
-Smoothing / hysteresis helpers (stubs).
+"""Smoothing helpers for time series.
 
 Exports:
-- ema(series: pd.Series, span: int=3) -> pd.Series
+- ema(series: pd.Series, span: int = 3) -> pd.Series
 """
 import pandas as pd
 

--- a/mw/scoring/tradability.py
+++ b/mw/scoring/tradability.py
@@ -1,13 +1,14 @@
-"""
-Tradability score & state machine (stubs).
+"""Tradability scoring and state classification utilities.
+
+Combines forecast error and latency into a tradability score and maps the
+score to ``"RED"``, ``"YELLOW"`` or ``"GREEN"`` states with hysteresis.
 
 Exports:
-- score_tradability(e_hat: pd.Series, l_hat: pd.Series,
-              weights: dict) -> pd.Series
-- state_machine(scores: pd.Series, prev_state: str,
-                thresholds: dict, hysteresis: dict,
-                timestamps: pd.Series=None) -> pd.Series
-States: "RED", "YELLOW", "GREEN".
+- score_tradability(e_hat: pd.Series, l_hat: pd.Series, weights: dict = None)
+  -> pd.Series
+- state_machine(scores: pd.Series, prev_state: str = None,
+                thresholds: dict = None, hysteresis: dict = None,
+                timestamps: pd.Series | None = None) -> pd.Series
 """
 
 from typing import Optional

--- a/mw/utils/ohlc_checks.py
+++ b/mw/utils/ohlc_checks.py
@@ -1,5 +1,7 @@
-"""
-OHLC integrity checks (stub).
+"""Integrity checks for OHLC price data.
+
+Exports:
+- validate_ohlc(df: pd.DataFrame) -> pd.Series
 """
 import pandas as pd
 

--- a/mw/utils/persistence.py
+++ b/mw/utils/persistence.py
@@ -1,8 +1,11 @@
 """Persistence helpers for common file formats.
 
-Currently only JSON writing is implemented. The helper ensures that data is
-written atomically so that partially written files are not left behind when a
-process is interrupted.
+Provides atomic write helpers for Parquet and JSON files to avoid partially
+written data when processes are interrupted.
+
+Exports:
+- write_parquet(df: pd.DataFrame, path: str) -> None
+- write_json(obj: Dict[str, Any], path: str) -> None
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- rewrite entropy module docstring to describe permutation and sample entropy helpers
- clarify smoothing, tradability, OHLC checks, and persistence docstrings to list their exports
- document atomic JSON and Parquet writers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a92762f39083228efd4a5ef7eed2b7