### PR TITLE
Handle JSON write errors gracefully

### DIFF
--- a/mw/utils/persistence.py
+++ b/mw/utils/persistence.py
@@ -68,4 +68,12 @@ def write_json(obj: Dict[str, Any], path: str) -> None:
         os.fsync(tmp.fileno())
         temp_name = tmp.name
 
-    os.replace(temp_name, target)
+    try:
+        os.replace(temp_name, target)
+    except OSError as err:
+        logging.error("Failed to write JSON file %s: %s", path, err)
+        try:
+            os.remove(temp_name)
+        except OSError:
+            pass
+        raise


### PR DESCRIPTION
## Summary
- Add try/except around os.replace in `write_json`
- Log errors and remove temporary file on failure

## Testing
- `pytest tests/test_persistence.py::test_write_json_round_trip -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9281546908322bc9f4a018e7554c7