### PR TITLE
Handle ties in permutation entropy

### DIFF
--- a/mw/features/entropy.py
+++ b/mw/features/entropy.py
@@ -17,6 +17,9 @@ import pandas as pd
 from scipy.spatial import cKDTree
 
 
+_rng = np.random.default_rng()
+
+
 def _ordinal_patterns(
     values: np.ndarray,
     m: int,
@@ -30,7 +33,13 @@ def _ordinal_patterns(
     patterns: List[Tuple[int, ...]] = []
     for i in range(n - (m - 1) * tau):
         window = values[i : i + (m - 1) * tau + 1 : tau]  # noqa: E203
-        inner = np.argsort(window, kind="mergesort")
+        if np.unique(window).size == 1:
+            inner = np.argsort(window, kind="mergesort")
+        else:
+            if np.unique(window).size < window.size:
+                jitter = _rng.uniform(-1e-10, 1e-10, size=window.size)
+                window = window + jitter
+            inner = np.argsort(window, kind="mergesort")
         ranks = np.argsort(inner, kind="mergesort")
         patterns.append(tuple(ranks))
     return patterns

--- a/tests/test_entropy.py
+++ b/tests/test_entropy.py
@@ -55,3 +55,14 @@ def test_sample_entropy_random_greater_than_deterministic():
     h_rand = sample_entropy(random_series, m=2, r=0.2)
     h_det = sample_entropy(deterministic, m=2, r=0.2)
     assert h_rand > h_det
+
+
+def test_permutation_entropy_with_repeated_values():
+    import mw.features.entropy as entropy
+
+    entropy._rng = np.random.default_rng(0)
+    series = pd.Series([1, 1, 2, 2, 3, 3] * 5)
+    h1 = permutation_entropy(series, m=3, tau=1)
+    entropy._rng = np.random.default_rng(0)
+    h2 = permutation_entropy(series, m=3, tau=1)
+    assert h1 == h2 and h1 > 0


### PR DESCRIPTION
## Summary
- break deterministic ordering of equal values in ordinal patterns by applying slight random jitter
- add test ensuring repeated values yield consistent entropy when RNG is seeded

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9280467948322a93d6a6251cc62db