### PR TITLE
Handle exceptions in minute loop steps

### DIFF
--- a/mw/live/minute_loop.py
+++ b/mw/live/minute_loop.py
@@ -10,6 +10,7 @@ minute boundaries.  Offsets (in seconds) are supplied via ``params`` and
 default to a small stagger between steps.
 """
 
+import logging
 import time
 from datetime import timedelta
 from typing import Any, Callable, Dict
@@ -51,4 +52,7 @@ def run_minute_loop(
         target = minute_start + timedelta(seconds=offsets.get(name, 0))
         sleep_for = (target - now_utc()).total_seconds()
         time.sleep(max(0.0, sleep_for))
-        fn()
+        try:
+            fn()
+        except Exception:
+            logging.exception("Exception in %s step", name)

--- a/tests/test_minute_loop.py
+++ b/tests/test_minute_loop.py
@@ -52,3 +52,33 @@ def test_run_minute_loop_calls_functions_in_order(monkeypatch):
 
     assert call_order == ["poll", "compute", "persist", "plot", "health"]
     assert sleeps == [1.0, 2.0, 0.0, 0.0, 0.0]
+
+
+def test_run_minute_loop_continues_after_failure(monkeypatch):
+    call_order = []
+
+    def poll():
+        raise ValueError("boom")
+
+    def compute():
+        call_order.append("compute")
+
+    def persist():
+        call_order.append("persist")
+
+    def plot():
+        call_order.append("plot")
+
+    def health():
+        call_order.append("health")
+
+    monkeypatch.setattr("time.sleep", lambda x: None)
+
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    monkeypatch.setattr("mw.live.minute_loop.now_utc", lambda: start)
+
+    params = {"minute_loop_offsets": {}}
+
+    run_minute_loop(poll, compute, persist, plot, health, params)
+
+    assert call_order == ["compute", "persist", "plot", "health"]


### PR DESCRIPTION
## Summary
- Log and swallow exceptions in each minute loop step, ensuring subsequent steps still execute
- Test that a failing step does not prevent later steps from running

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a928d06d0c8322a76243553744e992