### PR TITLE
Remove unused timestamps argument from tradability state machine

### DIFF
--- a/mw/scoring/tradability.py
+++ b/mw/scoring/tradability.py
@@ -7,8 +7,7 @@ Exports:
 - score_tradability(e_hat: pd.Series, l_hat: pd.Series, weights: dict = None)
   -> pd.Series
 - state_machine(scores: pd.Series, prev_state: str = None,
-                thresholds: dict = None, hysteresis: dict = None,
-                timestamps: pd.Series | None = None) -> pd.Series
+                thresholds: dict = None, hysteresis: dict = None) -> pd.Series
 """
 
 from typing import Optional
@@ -45,7 +44,6 @@ def state_machine(
     prev_state: Optional[str] = None,
     thresholds: dict = None,
     hysteresis: dict = None,
-    timestamps: Optional[pd.Series] = None,
 ) -> pd.Series:
     """
     Map scores to RED/YELLOW/GREEN with hysteresis:
@@ -53,9 +51,6 @@ def state_machine(
     - require ``k_down`` consecutive <= ``tau_y`` to turn RED
     - otherwise YELLOW
     - throttle flips by ``min_flip_spacing`` observations.
-
-    ``timestamps`` is accepted for future compatibility but spacing is
-    currently measured in number of observations.
     """
     thresholds = thresholds or DEFAULT_THRESH
     thresholds = {

--- a/tests/test_tradability.py
+++ b/tests/test_tradability.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 
 import pandas as pd
+import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from mw.scoring.tradability import (  # noqa: E402
@@ -52,3 +53,10 @@ def test_state_machine_hysteresis_and_spacing():
     result = state_machine(scores)
 
     pd.testing.assert_series_equal(result, expected)
+
+
+def test_state_machine_rejects_timestamps_argument():
+    scores = pd.Series([0.5, 0.7])
+    ts = pd.Series([1, 2])
+    with pytest.raises(TypeError):
+        state_machine(scores, timestamps=ts)


### PR DESCRIPTION
## Summary
- drop unused `timestamps` parameter from `state_machine`
- document observation-based spacing and add regression test for removed argument

## Testing
- `pre-commit run --files mw/scoring/tradability.py tests/test_tradability.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a92914731883229a4384ed3696c87d