### PR TITLE
Validate EMA span and test error handling

### DIFF
--- a/mw/features/smoothing.py
+++ b/mw/features/smoothing.py
@@ -20,7 +20,14 @@ def ema(series: pd.Series, span: int = 3) -> pd.Series:
     -------
     pd.Series
         Exponentially weighted moving average aligned with the input index.
+    
+    Raises
+    ------
+    ValueError
+        If ``span`` is less than or equal to zero.
     """
+    if span <= 0:
+        raise ValueError("span must be positive")
 
     result = series.ewm(span=span, adjust=False).mean()
     return result.loc[series.index]

--- a/tests/test_smoothing.py
+++ b/tests/test_smoothing.py
@@ -33,3 +33,11 @@ def test_ema_matches_manual_calculation_and_preserves_index():
     assert result.index.equals(x.index)
     assert result.tolist() == pytest.approx(expected.tolist())
 
+
+def test_ema_raises_on_non_positive_span():
+    x = pd.Series([1.0, 2.0])
+
+    for invalid_span in (0, -1):
+        with pytest.raises(ValueError):
+            ema(x, span=invalid_span)
+


### PR DESCRIPTION
## Summary
- ensure `ema` raises `ValueError` when `span` is non-positive
- document the new behavior
- add tests to cover invalid spans

## Testing
- `pytest tests/test_smoothing.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a929e666c483229887ee45a59d0bac