### PR TITLE
Add session logger and integrate into minute loop

### DIFF
--- a/mw/live/logger.py
+++ b/mw/live/logger.py
@@ -1,0 +1,66 @@
+"""Session logging utilities.
+
+Provides :class:`SessionLogger` to append per-minute observations to a CSV
+and write a JSON session summary on shutdown.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict
+
+from mw.utils.time import now_utc
+
+
+@dataclass
+class SessionLogger:
+    """Log per-minute results and summarise the session."""
+
+    csv_path: Path
+    summary_path: Path
+    start: datetime = field(default_factory=now_utc)
+    rows: int = 0
+
+    def log_minute(
+        self,
+        timestamp: datetime,
+        score: float,
+        state: str,
+        diagnostics: Dict[str, Any],
+    ) -> None:
+        """Append a record for ``timestamp`` to the CSV file."""
+
+        self.csv_path.parent.mkdir(parents=True, exist_ok=True)
+        exists = self.csv_path.exists()
+        with self.csv_path.open("a", newline="") as f:
+            writer = csv.DictWriter(
+                f, fieldnames=["timestamp", "score", "state", "diagnostics"]
+            )
+            if not exists:
+                writer.writeheader()
+            writer.writerow(
+                {
+                    "timestamp": timestamp.isoformat(),
+                    "score": score,
+                    "state": state,
+                    "diagnostics": json.dumps(diagnostics),
+                }
+            )
+        self.rows += 1
+
+    def close(self, **extra: Any) -> None:
+        """Write a JSON summary of the session."""
+
+        summary = {
+            "start": self.start.isoformat(),
+            "end": now_utc().isoformat(),
+            "rows": self.rows,
+        }
+        summary.update(extra)
+        self.summary_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.summary_path.open("w") as f:
+            json.dump(summary, f)

--- a/mw/live/minute_loop.py
+++ b/mw/live/minute_loop.py
@@ -2,7 +2,7 @@
 
 This module coordinates the high level steps executed every minute:
 
-``poll -> compute -> persist -> plot -> health``.
+``poll -> compute -> persist -> log -> plot -> health``.
 
 The function waits for configured offsets from the start of the current
 minute before invoking each step so that calls are synchronised with
@@ -22,6 +22,7 @@ def run_minute_loop(
     poll_fn: Callable,
     compute_fn: Callable,
     persist_fn: Callable,
+    log_fn: Callable,
     plot_fn: Callable,
     health_fn: Callable,
     params: Dict[str, Any],
@@ -36,7 +37,14 @@ def run_minute_loop(
 
     offsets = params.get(
         "minute_loop_offsets",
-        {"poll": 3, "compute": 5, "persist": 6, "plot": 7, "health": 8},
+        {
+            "poll": 3,
+            "compute": 5,
+            "persist": 6,
+            "log": 7,
+            "plot": 8,
+            "health": 9,
+        },
     )
 
     critical_steps = set(params.get("minute_loop_critical_steps", []))
@@ -47,6 +55,7 @@ def run_minute_loop(
         ("poll", poll_fn),
         ("compute", compute_fn),
         ("persist", persist_fn),
+        ("log", log_fn),
         ("plot", plot_fn),
         ("health", health_fn),
     ]

--- a/tests/test_live_logger.py
+++ b/tests/test_live_logger.py
@@ -1,0 +1,37 @@
+import sys
+import csv
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from mw.live.logger import SessionLogger  # noqa: E402
+
+
+def test_session_logger_writes_csv_and_summary(tmp_path):
+    csv_path = tmp_path / "log.csv"
+    summary_path = tmp_path / "summary.json"
+    logger = SessionLogger(csv_path, summary_path)
+
+    ts1 = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    ts2 = datetime(2024, 1, 1, 0, 1, tzinfo=timezone.utc)
+
+    logger.log_minute(ts1, 0.1, "GREEN", {"a": 1})
+    logger.log_minute(ts2, -0.2, "RED", {"b": 2})
+    logger.close(session="abc")
+
+    with csv_path.open() as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+    assert reader.fieldnames == ["timestamp", "score", "state", "diagnostics"]
+    assert rows[0]["timestamp"] == ts1.isoformat()
+    assert float(rows[0]["score"]) == 0.1
+    assert json.loads(rows[0]["diagnostics"]) == {"a": 1}
+    assert rows[1]["timestamp"] == ts2.isoformat()
+    assert rows[1]["state"] == "RED"
+
+    summary = json.loads(summary_path.read_text())
+    assert summary["rows"] == 2
+    assert "start" in summary and "end" in summary
+    assert summary["session"] == "abc"

--- a/tests/test_minute_loop.py
+++ b/tests/test_minute_loop.py
@@ -16,6 +16,7 @@ def test_run_minute_loop_calls_functions_in_order(monkeypatch):
     poll = mk("poll")
     compute = mk("compute")
     persist = mk("persist")
+    log = mk("log")
     plot = mk("plot")
     health = mk("health")
 
@@ -31,6 +32,7 @@ def test_run_minute_loop_calls_functions_in_order(monkeypatch):
             start + timedelta(seconds=5),
             start + timedelta(seconds=6),
             start + timedelta(seconds=7),
+            start + timedelta(seconds=8),
         ]
     )
     monkeypatch.setattr(
@@ -43,15 +45,23 @@ def test_run_minute_loop_calls_functions_in_order(monkeypatch):
             "poll": 3,
             "compute": 6,
             "persist": 7,
-            "plot": 8,
-            "health": 9,
+            "log": 8,
+            "plot": 9,
+            "health": 10,
         }
     }
 
-    run_minute_loop(poll, compute, persist, plot, health, params)
+    run_minute_loop(poll, compute, persist, log, plot, health, params)
 
-    assert call_order == ["poll", "compute", "persist", "plot", "health"]
-    assert sleeps == [1.0, 2.0, 0.0, 0.0, 0.0]
+    assert call_order == [
+        "poll",
+        "compute",
+        "persist",
+        "log",
+        "plot",
+        "health",
+    ]
+    assert sleeps == [1.0, 2.0, 0.0, 0.0, 0.0, 0.0]
 
 
 def test_run_minute_loop_continues_after_failure(monkeypatch):
@@ -66,6 +76,9 @@ def test_run_minute_loop_continues_after_failure(monkeypatch):
     def persist():
         call_order.append("persist")
 
+    def log():
+        call_order.append("log")
+
     def plot():
         call_order.append("plot")
 
@@ -79,9 +92,9 @@ def test_run_minute_loop_continues_after_failure(monkeypatch):
 
     params = {"minute_loop_offsets": {}}
 
-    run_minute_loop(poll, compute, persist, plot, health, params)
+    run_minute_loop(poll, compute, persist, log, plot, health, params)
 
-    assert call_order == ["compute", "persist", "plot", "health"]
+    assert call_order == ["compute", "persist", "log", "plot", "health"]
 
 
 def test_run_minute_loop_calls_error_fn(monkeypatch):
@@ -94,6 +107,9 @@ def test_run_minute_loop_calls_error_fn(monkeypatch):
         pass
 
     def persist():
+        pass
+
+    def log():
         pass
 
     def plot():
@@ -112,7 +128,7 @@ def test_run_minute_loop_calls_error_fn(monkeypatch):
 
     params = {"minute_loop_offsets": {}}
 
-    run_minute_loop(poll, compute, persist, plot, health, params, error_fn)
+    run_minute_loop(poll, compute, persist, log, plot, health, params, error_fn)
 
     assert errors and errors[0][0] == "poll"
     assert isinstance(errors[0][1], RuntimeError)
@@ -130,6 +146,9 @@ def test_run_minute_loop_skips_remaining_on_critical_failure(monkeypatch):
     def persist():
         call_order.append("persist")
 
+    def log():
+        call_order.append("log")
+
     def plot():
         call_order.append("plot")
 
@@ -143,6 +162,6 @@ def test_run_minute_loop_skips_remaining_on_critical_failure(monkeypatch):
 
     params = {"minute_loop_offsets": {}, "minute_loop_critical_steps": ["poll"]}
 
-    run_minute_loop(poll, compute, persist, plot, health, params)
+    run_minute_loop(poll, compute, persist, log, plot, health, params)
 
     assert call_order == []


### PR DESCRIPTION
## Summary
- add `SessionLogger` to append minute-level entries to CSV and emit JSON summary on shutdown
- expand `run_minute_loop` with a dedicated `log` step and offsets
- test logging behaviour and updated minute loop orchestration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9311cb01c83228b04ae74b466b8ab