### PR TITLE
Use explicit color mapping for price state plot

### DIFF
--- a/mw/viz/plots.py
+++ b/mw/viz/plots.py
@@ -34,12 +34,14 @@ def plot_price_with_state(df: pd.DataFrame, state_series: pd.Series):
     ax.plot(df.index, price)
     ax.set_ylabel("price")
 
-    # Map each distinct state to a color from the matplotlib color cycle
-    color_cycle = plt.rcParams["axes.prop_cycle"].by_key()["color"]
-    state_colors = {
-        state: color_cycle[i % len(color_cycle)]
-        for i, state in enumerate(pd.unique(states.dropna()))
+    # Explicit color mapping for known states
+    color_map = {
+        "GREEN": "#00ff00",
+        "YELLOW": "#ffff00",
+        "RED": "#ff0000",
     }
+    unique_states = pd.unique(states.dropna())
+    state_colors = {state: color_map[state] for state in unique_states}
 
     # Group consecutive identical states and shade the corresponding regions
     groups = (states != states.shift()).cumsum()

--- a/tests/test_plot_price_with_state.py
+++ b/tests/test_plot_price_with_state.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import matplotlib
 import pandas as pd
+from matplotlib.colors import to_hex
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 matplotlib.use("Agg")
@@ -10,17 +11,21 @@ matplotlib.use("Agg")
 from mw.viz.plots import plot_price_with_state  # noqa: E402
 
 
-def test_plot_price_with_state_line_and_patches():
-    df = pd.DataFrame({"price": [1, 2, 3, 4]}, index=[0, 1, 2, 3])
-    states = pd.Series(["A", "A", "B", "B"], index=df.index)
+def test_plot_price_with_state_color_mapping():
+    df = pd.DataFrame({"price": [1, 2, 3, 4, 5, 6]}, index=range(6))
+    states = pd.Series(
+        ["GREEN", "GREEN", "YELLOW", "YELLOW", "RED", "RED"], index=df.index
+    )
 
     fig = plot_price_with_state(df, states)
     try:
         ax = fig.axes[0]
-        assert ax.lines[0].get_ydata().tolist() == [1, 2, 3, 4]
-        assert len(ax.patches) == 2
-        # ensure different states produce different colors
-        colors = {tuple(p.get_facecolor()) for p in ax.patches}
-        assert len(colors) == 2
+        assert ax.lines[0].get_ydata().tolist() == [1, 2, 3, 4, 5, 6]
+        assert len(ax.patches) == 3
+        assert [to_hex(p.get_facecolor()) for p in ax.patches] == [
+            "#00ff00",
+            "#ffff00",
+            "#ff0000",
+        ]
     finally:
         fig.clf()


### PR DESCRIPTION
## Summary
- hard-code GREEN, YELLOW and RED state colors in price plotting utility
- test that price-state plot uses specific hex colors for each state

## Testing
- `pre-commit run --files mw/viz/plots.py tests/test_plot_price_with_state.py`
- `pytest tests/test_plot_price_with_state.py`


------
https://chatgpt.com/codex/tasks/task_e_68a931b963288322b4d1d48707fb173c