### PR TITLE
Add second-order feature utilities

### DIFF
--- a/mw/features/second_order.py
+++ b/mw/features/second_order.py
@@ -1,0 +1,61 @@
+"""Second-order time series features using causal differences.
+
+Exports
+-------
+velocity
+    First discrete derivative (velocity) of a series.
+curvature
+    Second discrete derivative (curvature) of a series.
+tension
+    Weighted combination ``alpha*(1 - e_hat) - beta*l_hat``.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def velocity(series: pd.Series) -> pd.Series:
+    """Return the causal first difference of ``series``.
+
+    Parameters
+    ----------
+    series : pd.Series
+        Input series.
+
+    Returns
+    -------
+    pd.Series
+        Velocity aligned with the input index where ``result[i] = series[i] - series[i-1]``.
+    """
+
+    return series.diff()
+
+
+def curvature(series: pd.Series) -> pd.Series:
+    """Return the causal second difference of ``series``.
+
+    This is simply the discrete difference of the velocity, equivalent to
+    ``series.diff().diff()``.
+    """
+
+    return series.diff().diff()
+
+
+def tension(e_hat: pd.Series, l_hat: pd.Series, *, alpha: float = 0.6, beta: float = 0.4) -> pd.Series:
+    """Return tension from normalized entropy and lambda features.
+
+    Parameters
+    ----------
+    e_hat, l_hat : pd.Series
+        Normalized entropy and lambda features in ``[0, 1]``.
+    alpha, beta : float, default 0.6 and 0.4
+        Weights applied to the two components.
+
+    Returns
+    -------
+    pd.Series
+        ``alpha * (1 - e_hat) - beta * l_hat`` aligned to the input index.
+    """
+
+    return alpha * (1 - e_hat) - beta * l_hat

--- a/tests/test_second_order.py
+++ b/tests/test_second_order.py
@@ -1,0 +1,34 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pandas.testing as pdt
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from mw.features.second_order import curvature, tension, velocity  # noqa: E402  # isort: skip
+
+
+def test_velocity_and_curvature_compute_causal_differences():
+    idx = pd.date_range("2024-01-01", periods=5, freq="D")
+    x = pd.Series([0.0, 1.0, 4.0, 9.0, 16.0], index=idx)
+
+    v = velocity(x)
+    c = curvature(x)
+
+    expected_v = pd.Series([float("nan"), 1.0, 3.0, 5.0, 7.0], index=idx)
+    expected_c = pd.Series([float("nan"), float("nan"), 2.0, 2.0, 2.0], index=idx)
+
+    pdt.assert_series_equal(v, expected_v)
+    pdt.assert_series_equal(c, expected_c)
+
+
+def test_tension_combines_scaled_features():
+    idx = pd.date_range("2024-01-01", periods=3, freq="D")
+    e_hat = pd.Series([0.2, 0.5, 0.8], index=idx)
+    l_hat = pd.Series([0.1, 0.2, 0.3], index=idx)
+
+    result = tension(e_hat, l_hat, alpha=0.6, beta=0.4)
+    expected = pd.Series(0.6 * (1 - e_hat) - 0.4 * l_hat, index=idx)
+
+    pdt.assert_series_equal(result, expected)


### PR DESCRIPTION
## Summary
- add velocity and curvature helpers using causal differences
- compute tension from scaled entropy and lambda metrics
- test second-order helpers on synthetic series

## Testing
- `pytest tests/test_second_order.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a93267e1f48322ad61d2e77cde1699