### PR TITLE
Include additional metadata fields in canonicalizer

### DIFF
--- a/tests/test_canonicalizer.py
+++ b/tests/test_canonicalizer.py
@@ -30,7 +30,12 @@ def make_sample_df():
 def test_canonicalize_end_to_end(tmp_path):
     raw = make_sample_df()
     out = tmp_path / "data.parquet"
-    canonicalize(raw, out.as_posix())
+    canonicalize(
+        raw,
+        out.as_posix(),
+        source="unit_test",
+        tz_of_source="America/New_York",
+    )
 
     result = pd.read_parquet(out)
     result["timestamp"] = pd.to_datetime(result["timestamp"], utc=True)
@@ -69,6 +74,10 @@ def test_canonicalize_end_to_end(tmp_path):
     assert meta["gaps"] == 1
     assert meta["contract_version"] == 1
     assert isinstance(meta["hash"], str) and len(meta["hash"]) == 64
+    assert meta["source"] == "unit_test"
+    assert meta["tz_of_source"] == "America/New_York"
+    assert isinstance(meta["loaded_at"], str)
+    assert meta["clip_count"] == 0
 
 
 def test_canonicalize_invalid_ohlc(tmp_path):
@@ -115,6 +124,10 @@ def test_canonicalize_empty(tmp_path):
     assert meta["rows"] == 0
     assert meta["duplicates"] == 0
     assert meta["gaps"] == 0
+    assert "source" in meta
+    assert "tz_of_source" in meta
+    assert isinstance(meta["loaded_at"], str)
+    assert meta["clip_count"] == 0
 
 
 def test_is_session_weekend(tmp_path):


### PR DESCRIPTION
## Summary
- extend canonicalizer metadata with source, tz_of_source, loaded_at, and clip_count
- default timezone to America/New_York when unspecified
- update canonicalizer tests to expect new metadata fields

## Testing
- `pre-commit run --files mw/io/canonicalizer.py tests/test_canonicalizer.py`
- `pytest tests/test_canonicalizer.py`


------
https://chatgpt.com/codex/tasks/task_e_68a933110aec8322b8cb29875c7dc2da