### PR TITLE
Persist features after compute and atomic decision logging

### DIFF
--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -1,4 +1,6 @@
+import csv
 import sys
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pandas as pd
@@ -8,6 +10,8 @@ from mw.adapters import polygon_rest  # noqa: E402
 from mw.features.scaling import minmax_causal  # noqa: E402
 from mw.features.smoothing import ema  # noqa: E402
 from mw.io.canonicalizer import canonicalize  # noqa: E402
+from mw.live import minute_loop  # noqa: E402
+from mw.live.logger import SessionLogger  # noqa: E402
 from mw.scoring.tradability import (score_tradability,  # noqa: E402
                                     state_machine)
 
@@ -59,3 +63,60 @@ def test_pipeline_integration(monkeypatch, tmp_path):
     )
 
     pd.testing.assert_series_equal(states, expected)
+
+
+def test_live_pipeline_persists_outputs(monkeypatch, tmp_path):
+    """Ensure compute results and decision logs are written to disk."""
+
+    monkeypatch.chdir(tmp_path)
+
+    # Time control
+    def gen():
+        t = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        while True:
+            yield t
+            t += timedelta(seconds=1)
+
+    times = gen()
+    monkeypatch.setattr(minute_loop, "now_utc", lambda: next(times))
+    monkeypatch.setattr("time.sleep", lambda x: None)
+
+    df1 = pd.DataFrame({"x": [1]})
+    df2 = pd.DataFrame({"x": [2]})
+    data_iter = iter([df1, df2])
+
+    def poll():
+        pass
+
+    def compute():
+        return {"feat": next(data_iter)}
+
+    def persist():
+        pass
+
+    logger = SessionLogger(Path("decisions.csv"), Path("summary.json"))
+
+    def log():
+        logger.log_minute(minute_loop.now_utc(), 0.1, "GREEN", {})
+
+    def plot():
+        pass
+
+    def health():
+        pass
+
+    params = {"minute_loop_offsets": {}}
+
+    for _ in range(2):
+        minute_loop.run_minute_loop(
+            poll, compute, persist, log, plot, health, params
+        )
+    logger.close()
+
+    assert (tmp_path / "data" / "feat.parquet").exists()
+    csv_path = tmp_path / "decisions.csv"
+    assert csv_path.exists()
+    with csv_path.open() as f:
+        rows = list(csv.DictReader(f))
+    assert len(rows) == 2
+    assert (tmp_path / "summary.json").exists()


### PR DESCRIPTION
## Summary
- persist feature DataFrames to `data/` after each compute step
- add durable CSV append helper and use it in `SessionLogger`
- write session summaries atomically and test file creation

## Testing
- `pytest tests/test_live_logger.py tests/test_minute_loop.py tests/test_persistence.py tests/test_pipeline_integration.py`

------
https://chatgpt.com/codex/tasks/task_e_68a9336ea1648322bd98c4a8861d38e0