### PR TITLE
Fail CI on test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,4 @@ jobs:
         run: pre-commit run --all-files
       - name: Tests
         run: |
-          python -m pytest -q || true
+          python -m pytest --maxfail=1 -q


### PR DESCRIPTION
## Summary
- ensure CI fails on test errors and stop after first failure

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest --maxfail=1`

------
https://chatgpt.com/codex/tasks/task_e_68a933f5f7b083228a969601e542df51