### PR TITLE
Introduce structured params loader and integrate

### DIFF
--- a/mw/scoring/tradability.py
+++ b/mw/scoring/tradability.py
@@ -4,46 +4,35 @@ Combines forecast error and latency into a tradability score and maps the
 score to ``"RED"``, ``"YELLOW"`` or ``"GREEN"`` states with hysteresis.
 
 Exports:
-- score_tradability(e_hat: pd.Series, l_hat: pd.Series, weights: dict = None)
-  -> pd.Series
+- score_tradability(
+    e_hat: pd.Series, l_hat: pd.Series, params: ScoreParams | None = None
+  ) -> pd.Series
 - state_machine(scores: pd.Series, prev_state: str = None,
-                thresholds: dict = None, hysteresis: dict = None) -> pd.Series
+                params: ScoreParams | None = None) -> pd.Series
 """
 
 from typing import Optional
 
 import pandas as pd
 
-DEFAULT_WEIGHTS = {"w1": 0.6, "w2": 0.4}
-DEFAULT_THRESH = {"tau_y": 0.45, "tau_g": 0.65}
-DEFAULT_HYST = {"k_up": 2, "k_down": 1, "min_flip_spacing": 3}
+from mw.utils.params import ScoreParams
 
 
 def score_tradability(
-    e_hat: pd.Series, l_hat: pd.Series, weights: dict = None
+    e_hat: pd.Series, l_hat: pd.Series, params: ScoreParams | None = None
 ) -> pd.Series:
     """𝒯 = w1*(1 - e_hat) + w2*(1 - l_hat), clipped to [0,1]."""
-    if weights is None:
-        weights = DEFAULT_WEIGHTS
-    else:
-        # fall back to defaults if keys missing
-        weights = {
-            "w1": weights.get("w1", DEFAULT_WEIGHTS["w1"]),
-            "w2": weights.get("w2", DEFAULT_WEIGHTS["w2"]),
-        }
-
+    params = params or ScoreParams()
     e_hat_aligned, l_hat_aligned = e_hat.align(l_hat, join="inner")
-
-    score = weights["w1"] * (1 - e_hat_aligned)
-    score += weights["w2"] * (1 - l_hat_aligned)
+    score = params.w1 * (1 - e_hat_aligned)
+    score += params.w2 * (1 - l_hat_aligned)
     return score.clip(0, 1)
 
 
 def state_machine(
     scores: pd.Series,
     prev_state: Optional[str] = None,
-    thresholds: dict = None,
-    hysteresis: dict = None,
+    params: ScoreParams | None = None,
 ) -> pd.Series:
     """
     Map scores to RED/YELLOW/GREEN with hysteresis:
@@ -52,26 +41,13 @@ def state_machine(
     - otherwise YELLOW
     - throttle flips by ``min_flip_spacing`` observations.
     """
-    thresholds = thresholds or DEFAULT_THRESH
-    thresholds = {
-        "tau_y": thresholds.get("tau_y", DEFAULT_THRESH["tau_y"]),
-        "tau_g": thresholds.get("tau_g", DEFAULT_THRESH["tau_g"]),
-    }
+    params = params or ScoreParams()
 
-    hysteresis = hysteresis or DEFAULT_HYST
-    hysteresis = {
-        "k_up": hysteresis.get("k_up", DEFAULT_HYST["k_up"]),
-        "k_down": hysteresis.get("k_down", DEFAULT_HYST["k_down"]),
-        "min_flip_spacing": hysteresis.get(
-            "min_flip_spacing", DEFAULT_HYST["min_flip_spacing"]
-        ),
-    }
-
-    tau_y = thresholds["tau_y"]
-    tau_g = thresholds["tau_g"]
-    k_up = hysteresis["k_up"]
-    k_down = hysteresis["k_down"]
-    min_flip_spacing = hysteresis["min_flip_spacing"]
+    tau_y = params.tau_y
+    tau_g = params.tau_g
+    k_up = params.k_up
+    k_down = params.k_down
+    min_flip_spacing = params.min_flip_spacing
 
     current_state = prev_state or "YELLOW"
     last_flip_idx = -min_flip_spacing

--- a/mw/utils/params.py
+++ b/mw/utils/params.py
@@ -1,0 +1,126 @@
+"""Configuration loader and structured parameter objects."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class PEParams:
+    """Permutation entropy parameters."""
+
+    window: int = 60
+    m: int = 3
+    tau: int = 1
+
+
+@dataclass
+class FTLEParams:
+    """Finite-time Lyapunov exponent parameters."""
+
+    window: int = 200
+    m: int = 3
+    tau: int = 1
+    horizon: int = 10
+    theiler: int = 2
+
+
+@dataclass
+class SmoothingParams:
+    """Smoothing configuration."""
+
+    ema_span: int = 3
+
+
+@dataclass
+class ScoreParams:
+    """Tradability scoring and state machine parameters."""
+
+    w1: float = 0.6
+    w2: float = 0.4
+    tau_y: float = 0.45
+    tau_g: float = 0.65
+    k_up: int = 2
+    k_down: int = 1
+    min_flip_spacing: int = 3
+
+
+@dataclass
+class NormalizationParams:
+    """Normalisation parameters."""
+
+    method: str = "minmax"
+
+
+@dataclass
+class MinuteLoopParams:
+    """Minute loop orchestration parameters."""
+
+    offsets: Dict[str, int] = field(
+        default_factory=lambda: {
+            "poll": 3,
+            "compute": 5,
+            "persist": 6,
+            "log": 7,
+            "plot": 8,
+            "health": 9,
+        }
+    )
+    critical_steps: list[str] = field(default_factory=list)
+    freshness_stale_threshold: float = 180.0
+
+
+@dataclass
+class Params:
+    """Structured configuration object for the application."""
+
+    granularity: str = "1min"
+    symbol: str = "C:XAUUSD"
+    pe: PEParams = field(default_factory=PEParams)
+    ftle: FTLEParams = field(default_factory=FTLEParams)
+    smoothing: SmoothingParams = field(default_factory=SmoothingParams)
+    score: ScoreParams = field(default_factory=ScoreParams)
+    normalization: NormalizationParams = field(
+        default_factory=NormalizationParams,
+    )
+    minute_loop: MinuteLoopParams = field(default_factory=MinuteLoopParams)
+
+
+_DEF_PATH = Path(__file__).resolve().parents[2] / "params" / "params_v1.json"
+
+
+def _merge(defaults: Any, data: Dict[str, Any]) -> Dict[str, Any]:
+    base = asdict(defaults)
+    for k, v in data.items():
+        if isinstance(v, dict) and isinstance(base.get(k), dict):
+            base[k].update(v)
+        else:
+            base[k] = v
+    return base
+
+
+def load_params(path: Optional[Path] = None) -> Params:
+    """Load configuration from ``path`` into a :class:`Params` instance."""
+    path = path or _DEF_PATH
+    with Path(path).open() as f:
+        raw = json.load(f)
+    defaults = Params()
+    return Params(
+        granularity=raw.get("granularity", defaults.granularity),
+        symbol=raw.get("symbol", defaults.symbol),
+        pe=PEParams(**_merge(defaults.pe, raw.get("pe", {}))),
+        ftle=FTLEParams(**_merge(defaults.ftle, raw.get("ftle", {}))),
+        smoothing=SmoothingParams(
+            **_merge(defaults.smoothing, raw.get("smoothing", {}))
+        ),
+        score=ScoreParams(**_merge(defaults.score, raw.get("score", {}))),
+        normalization=NormalizationParams(
+            **_merge(defaults.normalization, raw.get("normalization", {}))
+        ),
+        minute_loop=MinuteLoopParams(
+            **_merge(defaults.minute_loop, raw.get("minute_loop", {}))
+        ),
+    )

--- a/tests/test_entropy.py
+++ b/tests/test_entropy.py
@@ -1,3 +1,4 @@
+# isort:skip_file
 import sys
 from pathlib import Path
 
@@ -10,6 +11,7 @@ from mw.features.entropy import (  # noqa: E402
     rolling_permutation_entropy,
     sample_entropy,
 )
+from mw.utils.params import Params  # noqa: E402
 
 
 def test_monotonic_series_has_zero_entropy():
@@ -31,13 +33,19 @@ def test_random_series_has_high_entropy():
 
 def test_rolling_permutation_entropy_alignment():
     series = pd.Series([1, 3, 2, 4, 5, 0])
-    window = 4
-    result = rolling_permutation_entropy(series, window=window)
+    params = Params()
+    params.pe.window = 4
+    result = rolling_permutation_entropy(
+        series,
+        window=params.pe.window,
+        m=params.pe.m,
+        tau=params.pe.tau,
+    )
 
     expected = pd.Series([np.nan] * len(series))
-    for i in range(window - 1, len(series)):
+    for i in range(params.pe.window - 1, len(series)):
         expected.iloc[i] = permutation_entropy(
-            series.iloc[i - window + 1 : i + 1]
+            series.iloc[i - params.pe.window + 1 : i + 1]  # noqa: E203
         )
 
     pd.testing.assert_series_equal(result, expected)

--- a/tests/test_params_loader.py
+++ b/tests/test_params_loader.py
@@ -1,0 +1,12 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from mw.utils.params import Params, load_params  # noqa: E402
+
+
+def test_default_params_match_json():
+    params = Params()
+    loaded = load_params()
+    assert loaded == params

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -1,3 +1,4 @@
+# isort:skip_file
 import csv
 import sys
 from datetime import datetime, timedelta, timezone
@@ -12,8 +13,11 @@ from mw.features.smoothing import ema  # noqa: E402
 from mw.io.canonicalizer import canonicalize  # noqa: E402
 from mw.live import minute_loop  # noqa: E402
 from mw.live.logger import SessionLogger  # noqa: E402
-from mw.scoring.tradability import (score_tradability,  # noqa: E402
-                                    state_machine)
+from mw.scoring.tradability import (  # noqa: E402
+    score_tradability,
+    state_machine,
+)
+from mw.utils.params import Params  # noqa: E402
 
 
 def test_pipeline_integration(monkeypatch, tmp_path):
@@ -105,11 +109,18 @@ def test_live_pipeline_persists_outputs(monkeypatch, tmp_path):
     def health():
         pass
 
-    params = {"minute_loop_offsets": {}}
+    params = Params()
+    params.minute_loop.offsets = {}
 
     for _ in range(2):
         minute_loop.run_minute_loop(
-            poll, compute, persist, log, plot, health, params
+            poll,
+            compute,
+            persist,
+            log,
+            plot,
+            health,
+            params,
         )
     logger.close()
 

--- a/tests/test_tradability.py
+++ b/tests/test_tradability.py
@@ -10,6 +10,7 @@ from mw.scoring.tradability import (  # noqa: E402
     score_tradability,
     state_machine,
 )
+from mw.utils.params import ScoreParams  # noqa: E402
 
 
 def test_score_tradability_default_weights_align_and_clip():
@@ -25,10 +26,10 @@ def test_score_tradability_default_weights_align_and_clip():
 def test_score_tradability_custom_weights_and_clip():
     e_hat = pd.Series([-0.5, 2.0])
     l_hat = pd.Series([-0.5, 2.0])
-    weights = {"w1": 0.5, "w2": 0.5}
+    params = ScoreParams(w1=0.5, w2=0.5)
     expected = pd.Series([1.0, 0.0])
 
-    result = score_tradability(e_hat, l_hat, weights)
+    result = score_tradability(e_hat, l_hat, params)
 
     pd.testing.assert_series_equal(result, expected)
 
@@ -50,7 +51,7 @@ def test_state_machine_hysteresis_and_spacing():
         index=scores.index,
     )
 
-    result = state_machine(scores)
+    result = state_machine(scores, params=ScoreParams())
 
     pd.testing.assert_series_equal(result, expected)
 


### PR DESCRIPTION
## Summary
- add dataclass-based `Params` loader and helpers for features, scoring, and minute loop
- refactor scoring and minute loop components to use structured parameters
- test configuration defaults against `params_v1.json`

## Testing
- `pre-commit run --files mw/utils/params.py mw/scoring/tradability.py mw/live/minute_loop.py tests/test_tradability.py tests/test_minute_loop.py tests/test_pipeline_integration.py tests/test_entropy.py tests/test_params_loader.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a934938f6c8322bcaf6c339637f93a