### PR TITLE
Add Polygon quotes adapter with pagination

### DIFF
--- a/mw/adapters/polygon_quotes.py
+++ b/mw/adapters/polygon_quotes.py
@@ -1,0 +1,101 @@
+"""Polygon quotes adapter with pagination."""
+
+from __future__ import annotations
+
+import random
+import time
+from typing import List
+
+import pandas as pd
+import requests
+
+from .polygon_rest import BASE_URL, _get_api_key, _get_session, _REQUESTS_GET
+
+
+def fetch_quotes(
+    ticker: str, start: str | int, end: str | int, limit: int = 50_000
+) -> pd.DataFrame:
+    """Fetch NBBO quotes for ``ticker`` between ``start`` and ``end``.
+
+    Parameters
+    ----------
+    ticker:
+        Ticker symbol such as ``"AAPL"``.
+    start, end:
+        Either ``YYYY-MM-DD`` date strings or nanosecond timestamps understood
+        by the Polygon quotes endpoint.
+    limit:
+        Maximum number of rows to request from Polygon per page
+        (default 50,000).
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with columns ``ts_utc``, ``bid``, ``ask``, ``mid`` and
+        ``venue`` (if available).
+    """
+
+    api_key = _get_api_key()
+    url = f"{BASE_URL}/v3/quotes/{ticker}"
+    params = {
+        "timestamp.gte": start,
+        "timestamp.lte": end,
+        "limit": limit,
+        "sort": "timestamp",
+        "order": "asc",
+        "apiKey": api_key,
+    }
+    session = _get_session()
+    get_call = session.get if requests.get is _REQUESTS_GET else requests.get
+
+    all_results: List[dict] = []
+    while url:
+        resp = None
+        for attempt in range(3):
+            resp = get_call(url, params=params if params is not None else None, timeout=10)
+            if resp.status_code == 429 or resp.status_code >= 500:
+                if attempt == 2:
+                    resp.raise_for_status()
+                sleep_time = (2**attempt) + random.uniform(0, 1)
+                time.sleep(sleep_time)
+                continue
+            resp.raise_for_status()
+            break
+        else:  # pragma: no cover - safety
+            raise RuntimeError("Polygon API request failed")
+
+        data = resp.json()
+        results = data.get("results", [])
+        all_results.extend(results)
+        next_url = data.get("next_url")
+        if next_url:
+            if "apiKey" not in next_url:
+                next_url = f"{next_url}&apiKey={api_key}"
+            url = next_url
+            params = None
+        else:
+            url = None
+
+    if not all_results:
+        return pd.DataFrame(columns=["ts_utc", "bid", "ask", "mid", "venue"])
+
+    df = pd.DataFrame(all_results)
+    if "sip_timestamp" in df.columns:
+        df["ts_utc"] = pd.to_datetime(df["sip_timestamp"], unit="ns", utc=True)
+    else:
+        df["ts_utc"] = pd.to_datetime(df["timestamp"], unit="ns", utc=True)
+    df["bid"] = df["bid_price"]
+    df["ask"] = df["ask_price"]
+    df["mid"] = (df["bid"] + df["ask"]) / 2
+
+    venue_col = None
+    for col in ("participant_exchange", "exchange", "x"):
+        if col in df.columns:
+            venue_col = col
+            break
+    if venue_col is not None:
+        df["venue"] = df[venue_col]
+    else:
+        df["venue"] = pd.NA
+
+    return df[["ts_utc", "bid", "ask", "mid", "venue"]]

--- a/tests/test_polygon_quotes.py
+++ b/tests/test_polygon_quotes.py
@@ -1,0 +1,93 @@
+import pandas as pd
+import requests
+import pytest
+
+from mw.adapters import polygon_quotes
+
+
+class DummyResponse:
+    def __init__(self, payload, status_code=200):
+        self.payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code != 200:
+            raise requests.HTTPError(str(self.status_code))
+
+    def json(self):
+        return self.payload
+
+
+class FailingResponse:
+    def __init__(self, status_code):
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        raise requests.HTTPError(str(self.status_code))
+
+    def json(self):
+        return {}
+
+
+def test_fetch_quotes_paginates(monkeypatch):
+    payload1 = {
+        "results": [
+            {"sip_timestamp": 0, "bid_price": 1.0, "ask_price": 2.0, "participant_exchange": "V"},
+            {"sip_timestamp": 1, "bid_price": 1.1, "ask_price": 2.1, "participant_exchange": "V"},
+        ],
+        "next_url": "https://api.polygon.io/v3/quotes/XYZ?cursor=abc",
+    }
+    payload2 = {
+        "results": [
+            {"sip_timestamp": 2, "bid_price": 1.2, "ask_price": 2.2},
+            {"sip_timestamp": 3, "bid_price": 1.3, "ask_price": 2.3},
+        ]
+    }
+    responses = [DummyResponse(payload1), DummyResponse(payload2)]
+    calls = []
+
+    def fake_get(url, params=None, timeout=10):
+        calls.append((url, params))
+        return responses.pop(0)
+
+    monkeypatch.setenv("POLYGON_API_KEY", "KEY")
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    df = polygon_quotes.fetch_quotes("XYZ", 0, 3, limit=2)
+
+    assert calls[0][0] == "https://api.polygon.io/v3/quotes/XYZ"
+    assert calls[0][1]["apiKey"] == "KEY"
+    assert calls[1][0] == "https://api.polygon.io/v3/quotes/XYZ?cursor=abc&apiKey=KEY"
+    assert calls[1][1] is None
+
+    expected_ts = pd.to_datetime([0, 1, 2, 3], unit="ns", utc=True)
+    assert df["ts_utc"].tolist() == list(expected_ts)
+    assert df["bid"].tolist() == [1.0, 1.1, 1.2, 1.3]
+    assert df["ask"].tolist() == [2.0, 2.1, 2.2, 2.3]
+    assert df["mid"].tolist() == pytest.approx([1.5, 1.6, 1.7, 1.8])
+    assert list(df.columns) == ["ts_utc", "bid", "ask", "mid", "venue"]
+    assert df["ts_utc"].is_monotonic_increasing
+
+
+def test_fetch_quotes_retries_on_429(monkeypatch):
+    payload = {"results": [{"sip_timestamp": 0, "bid_price": 1.0, "ask_price": 2.0}]}
+    responses = [FailingResponse(429), DummyResponse(payload)]
+    calls = {"n": 0}
+
+    def fake_get(url, params=None, timeout=10):
+        resp = responses[calls["n"]]
+        calls["n"] += 1
+        return resp
+
+    monkeypatch.setenv("POLYGON_API_KEY", "KEY")
+    monkeypatch.setattr(requests, "get", fake_get)
+    monkeypatch.setattr(polygon_quotes.time, "sleep", lambda s: None)
+
+    df = polygon_quotes.fetch_quotes("XYZ", 0, 0)
+
+    assert calls["n"] == 2
+    expected_ts = pd.to_datetime([0], unit="ns", utc=True)
+    assert df["ts_utc"].tolist() == list(expected_ts)
+    assert df["bid"].tolist() == [1.0]
+    assert df["ask"].tolist() == [2.0]
+    assert df["mid"].tolist() == [1.5]


### PR DESCRIPTION
## Summary
- add Polygon v3 quotes adapter with pagination support and backoff
- include unit tests validating pagination and 429 retry behavior

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9477a724883229fdb468db3c3eeb1